### PR TITLE
Add missing about instance info translations

### DIFF
--- a/public/lang/ar.json
+++ b/public/lang/ar.json
@@ -73,6 +73,9 @@
     "edit-share-mode": "عدل",
     "expand_title": "Expand header button row"
   },
+  "about": {
+    "instance-info": "هذا التطبيق هو عميل مُحسَّن لخدمتي ErikrafT Drop وPairDrop. اختر إحدى الحالات التالية أو حدِّد عنوان URL مخصصًا للاتصال. الإعداد الافتراضي الموصى به: drop.erikraft.com. ملاحظة: يجب عليك اختيار عنوان URL نفسه على جميع الأجهزة."
+  },
   "instructions": {
     "x-instructions_mobile": "انقر لإرسال الملفات أو انقر لفترة طويلة لإرسال رسالة",
     "x-instructions-share-mode_desktop": "انقر للإرسال {{descriptor}}",

--- a/public/lang/bn.json
+++ b/public/lang/bn.json
@@ -31,5 +31,8 @@
     "activate-share-mode-and-other-files-plural": "অন্য ফাইল যোগ করুন",
     "activate-share-mode-shared-text": "পাঠানো টেক্সট",
     "activate-share-mode-shared-files-plural": "পাঠানো ফাইল গুলো"
+  },
+  "about": {
+    "instance-info": "এই অ্যাপটি ErikrafT Drop এবং PairDrop-এর জন্য অনুকূলিত ক্লায়েন্ট। সংযোগ করতে নিম্নলিখিত যে কোনো একটি ইনস্ট্যান্স বেছে নিন অথবা কাস্টম URL নির্দিষ্ট করুন। সুপারিশকৃত ডিফল্ট: drop.erikraft.com। নোট: আপনাকে সব ডিভাইসে একই URL বেছে নিতে হবে।"
   }
 }

--- a/public/lang/fi.json
+++ b/public/lang/fi.json
@@ -18,5 +18,8 @@
         "no-peers-title": "Avaa ErikrafT Drop muilla laitteilla lähettääksesi tiedostoja",
         "no-peers-subtitle": "Yhdistä laite tai liity julkiseen huoneeseen, jotta olet löydettävissä muissa verkoissa",
         "x-instructions_desktop": "Paina lähettääksesi tiedoston tai klikkaa oikealla painikkeella lähettääksesi viestin"
+    },
+    "about": {
+        "instance-info": "Tämä sovellus on optimoitu asiakas ErikrafT Dropille ja PairDropille. Valitse jokin seuraavista instansseista tai määritä yhteyttä varten oma URL-osoite. Suositeltu oletus: drop.erikraft.com. Huomautus: sinun on valittava sama URL kaikilla laitteilla."
     }
 }


### PR DESCRIPTION
## Summary
- add the about.instance-info string to the Arabic, Bengali, and Finnish locales to mirror the new ErikrafT Drop guidance

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68e4443e54a0832aa5171e0349e0dd58

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a localized About section with instance information in Arabic, Bengali, and Finnish.
  * Users in these languages now see guidance on configuring clients, selecting an instance URL, and using the same URL across devices.
  * Enhances the multilingual experience by expanding available translations without impacting existing functionality.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->