### PR TITLE
Improve About page download badges on mobile

### DIFF
--- a/public/index.html
+++ b/public/index.html
@@ -923,27 +923,27 @@
 </div>
 
         <!-- Botões com Imagens -->
-        <div class="row" style="margin: 1em 0; gap: 10px; flex-wrap: wrap; justify-content: center;">
-            <a href="https://drop.erikraft.com/" target="_blank">
-                <img src="https://i.imgur.com/9uq39iu.png" alt="Get it on Web" style="height: 80px;">
+        <div class="download-badge-grid">
+            <a class="download-badge" href="https://drop.erikraft.com/" target="_blank">
+                <img src="https://i.imgur.com/9uq39iu.png" alt="Get it on Web">
             </a>
-            <a id="githubDownloadAndroid" href="https://github.com/erikraft/Drop-Android/releases/latest/download/Drop-Android.apk" target="_blank">
-                <img src="https://i.imgur.com/nxlokSi.png" alt="Download the APK" style="height: 80px;">
+            <a class="download-badge" id="githubDownloadAndroid" href="https://github.com/erikraft/Drop-Android/releases/latest/download/Drop-Android.apk" target="_blank">
+                <img src="https://i.imgur.com/nxlokSi.png" alt="Download the APK">
             </a>
-            <a href="https://play.google.com/store/apps/details?id=com.erikraft.drop" target="_blank">
-                <img src="https://play.google.com/intl/en_us/badges/static/images/badges/en_badge_web_generic.png" alt="Get it on Google Play" style="height: 80px;">
+            <a class="download-badge" href="https://play.google.com/store/apps/details?id=com.erikraft.drop" target="_blank">
+                <img src="https://play.google.com/intl/en_us/badges/static/images/badges/en_badge_web_generic.png" alt="Get it on Google Play">
             </a>
-            <a href="https://f-droid.org/en/packages/com.erikraft.drop/" target="_blank">
-                <img src="https://fdroid.gitlab.io/artwork/badge/get-it-on.png" alt="Get it on F-Droid" style="height: 80px;">
+            <a class="download-badge" href="https://f-droid.org/en/packages/com.erikraft.drop/" target="_blank">
+                <img src="https://fdroid.gitlab.io/artwork/badge/get-it-on.png" alt="Get it on F-Droid">
             </a>
-            <a href="https://marketplace.visualstudio.com/items?itemName=ErikrafT.erikraft-drop" target="_blank">
-                <img src="https://i.imgur.com/fBWr0lN.png" alt="Get it on VS Code Marketplace" style="height: 80px;">
+            <a class="download-badge" href="https://marketplace.visualstudio.com/items?itemName=ErikrafT.erikraft-drop" target="_blank">
+                <img src="https://i.imgur.com/fBWr0lN.png" alt="Get it on VS Code Marketplace">
             </a>
-            <a href="https://open-vsx.org/extension/ErikrafT/erikraft-drop" target="_blank">
-                <img src="https://i.imgur.com/1OJsWQz.png" alt="Get it on Open VSX Registry" style="height: 80px;">
+            <a class="download-badge" href="https://open-vsx.org/extension/ErikrafT/erikraft-drop" target="_blank">
+                <img src="https://i.imgur.com/1OJsWQz.png" alt="Get it on Open VSX Registry">
             </a>
-            <a href="https://addons.mozilla.org/pt-BR/firefox/addon/erikraft-drop/" target="_blank">
-                <img src="https://i.imgur.com/2MubKYT.png" alt="Firefox Browser ADD-ONS" style="height: 80px;">
+            <a class="download-badge" href="https://addons.mozilla.org/pt-BR/firefox/addon/erikraft-drop/" target="_blank">
+                <img src="https://i.imgur.com/2MubKYT.png" alt="Firefox Browser ADD-ONS">
             </a>
         </div>
     </section>

--- a/public/styles/styles-main.css
+++ b/public/styles/styles-main.css
@@ -791,6 +791,105 @@ html[dir="rtl"] #about x-background {
     margin: 8px 8px -16px;
 }
 
+#about .download-badge-grid {
+    display: flex;
+    flex-wrap: wrap;
+    justify-content: center;
+    gap: 16px;
+    margin: 16px 0 24px;
+}
+
+#about .download-badge {
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    flex: 1 1 180px;
+    max-width: 220px;
+    padding: 12px 16px;
+    border-radius: 18px;
+    background: linear-gradient(145deg,
+            rgba(var(--shadow-color-secondary-rgb), 0.14),
+            rgba(var(--shadow-color-secondary-cover-rgb), 0.06));
+    border: 1px solid rgba(var(--shadow-color-secondary-rgb), 0.16);
+    backdrop-filter: blur(10px);
+    -webkit-backdrop-filter: blur(10px);
+    box-shadow: 0 12px 28px rgba(var(--shadow-color-secondary-cover-rgb), 0.2);
+    transition: transform 200ms ease, box-shadow 200ms ease, background 200ms ease;
+}
+
+#about .download-badge img {
+    display: block;
+    width: 100%;
+    height: auto;
+    max-height: 78px;
+}
+
+#about .download-badge:hover,
+#about .download-badge:focus-visible {
+    transform: translateY(-4px);
+    background: linear-gradient(145deg,
+            rgba(var(--shadow-color-secondary-rgb), 0.18),
+            rgba(var(--shadow-color-secondary-cover-rgb), 0.1));
+    box-shadow: 0 16px 32px rgba(var(--shadow-color-secondary-cover-rgb), 0.28);
+}
+
+body.dark-theme #about .download-badge {
+    background: linear-gradient(145deg,
+            rgba(var(--shadow-color-secondary-cover-rgb), 0.32),
+            rgba(var(--shadow-color-secondary-rgb), 0.18));
+    border-color: rgba(var(--shadow-color-secondary-rgb), 0.24);
+    box-shadow: 0 12px 28px rgba(var(--shadow-color-secondary-rgb), 0.14);
+}
+
+body.dark-theme #about .download-badge:hover,
+body.dark-theme #about .download-badge:focus-visible {
+    background: linear-gradient(145deg,
+            rgba(var(--shadow-color-secondary-cover-rgb), 0.4),
+            rgba(var(--shadow-color-secondary-rgb), 0.24));
+    box-shadow: 0 16px 34px rgba(var(--shadow-color-secondary-rgb), 0.18);
+}
+
+@media (prefers-color-scheme: dark) {
+    body:not(.light-theme) #about .download-badge {
+        background: linear-gradient(145deg,
+                rgba(var(--shadow-color-secondary-cover-rgb), 0.32),
+                rgba(var(--shadow-color-secondary-rgb), 0.18));
+        border-color: rgba(var(--shadow-color-secondary-rgb), 0.24);
+        box-shadow: 0 12px 28px rgba(var(--shadow-color-secondary-rgb), 0.14);
+    }
+
+    body:not(.light-theme) #about .download-badge:hover,
+    body:not(.light-theme) #about .download-badge:focus-visible {
+        background: linear-gradient(145deg,
+                rgba(var(--shadow-color-secondary-cover-rgb), 0.4),
+                rgba(var(--shadow-color-secondary-rgb), 0.24));
+        box-shadow: 0 16px 34px rgba(var(--shadow-color-secondary-rgb), 0.18);
+    }
+}
+
+@media (max-width: 720px) {
+    #about .download-badge-grid {
+        gap: 12px;
+    }
+
+    #about .download-badge {
+        flex: 1 1 calc(50% - 12px);
+        max-width: 240px;
+        padding: 12px;
+    }
+
+    #about .download-badge img {
+        max-height: none;
+    }
+}
+
+@media (max-width: 480px) {
+    #about .download-badge {
+        flex: 1 1 100%;
+        max-width: 320px;
+    }
+}
+
 #about section {
     flex-grow: 1;
 }


### PR DESCRIPTION
## Summary
- replace the inline-styled download badge row with semantic wrappers
- add responsive styling so the badge grid adapts cleanly on smaller screens
- soften the About badge backgrounds so the buttons blend with the overlay instead of appearing as white tiles

## Testing
- npm start

------
https://chatgpt.com/codex/tasks/task_e_68e50e961a50832ab9153eec0cdfef70