### PR TITLE
Fix footer column layout and add app availability feature

### DIFF
--- a/Website About/NEW/index.html
+++ b/Website About/NEW/index.html
@@ -281,11 +281,19 @@
                   <div class="w-14 h-14 bg-indigo-100 rounded-full flex items-center justify-center mb-6">
                      <svg xmlns="http://www.w3.org/2000/svg" height="40px" viewBox="0 -960 960 960" width="40px" fill="#5046e5">
                         <path d="M354.67-120h-168q-27 0-46.84-19.83Q120-159.67 120-186.67v-168q45.33-3.33 78.33-33.16 33-29.84 33-74.17t-33-74.17q-33-29.83-78.33-33.16v-168q0-27 19.83-46.84Q159.67-804 186.67-804H358q7.33-40.67 36-68.33Q422.67-900 463.33-900q40.67 0 69.34 27.67 28.66 27.66 36 68.33h168.66q27 0 46.84 19.83Q804-764.33 804-737.33v168.66q40.67 7.34 67.33 37.34 26.67 30 26.67 70.66 0 40.67-26.67 68.34-26.66 27.66-67.33 35v170.66q0 27-19.83 46.84Q764.33-120 737.33-120h-168q-3.33-48.67-34.16-80-30.84-31.33-73.17-31.33T388.83-200q-30.83 31.33-34.16 80Z"/>
-                      </svg>
+                     </svg>
 
                   </div>
                   <h3 class="text-xl font-semibold text-gray-800 mb-3">Extensão Disponível</h3>
                   <p class="text-gray-600"> Extensão Disponível no <a href="https://addons.mozilla.org/pt-BR/firefox/addon/erikraft-drop/" target="_blank" rel="noopener noreferrer" style="color: #2563eb;">Firefox Browser Add-ons</a>, <a href="https://marketplace.visualstudio.com/items?itemName=ErikrafT.erikraft-drop" target="_blank" rel="noopener noreferrer" style="color: #2563eb;">VS Code Marketplace</a> e no <a href="https://open-vsx.org/extension/ErikrafT/erikraft-drop" target="_blank" rel="noopener noreferrer" style="color: #2563eb;">Open VSX Registry</a> para acessar o site de forma fácil e rápida.</p>
+               </div>
+               <!-- Feature 9 -->
+               <div class="feature-card bg-white p-8 rounded-xl shadow-md transition-all duration-300">
+                  <div class="w-14 h-14 bg-indigo-100 rounded-full flex items-center justify-center mb-6">
+                     <i class="fa-solid fa-mobile-screen-button text-indigo-600 text-3xl"></i>
+                  </div>
+                  <h3 class="text-xl font-semibold text-gray-800 mb-3">Aplicativo disponível</h3>
+                  <p class="text-gray-600">Use o ErikrafT Drop como app dedicado baixando pela <a href="https://play.google.com/store/apps/details?id=com.erikraft.drop" target="_blank" rel="noopener noreferrer" style="color: #2563eb;">Google Play</a>, instalando via <a href="https://f-droid.org/en/packages/com.erikraft.drop/" target="_blank" rel="noopener noreferrer" style="color: #2563eb;">F-Droid</a> ou baixando o <a href="https://github.com/erikraft/Drop/releases/latest/download/Drop-Android.apk" target="_blank" rel="noopener noreferrer" style="color: #2563eb;">APK oficial</a> disponível também no rodapé.</p>
                </div>
             </div>
          </div>
@@ -582,6 +590,7 @@
                      <i class="fab fa-discord text-xl"></i>
                      </a>
                   </div>
+               </div>
                <div>
                   <h3 class="text-white font-semibold text-lg mb-4">Links úteis</h3>
                   <ul class="space-y-2">


### PR DESCRIPTION
## Summary
- add a new feature card promoting the mobile app with links to Google Play, F-Droid, and APK download
- close the footer column wrapper to restore the four-column layout

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68e569223230832abc0ded3f9135d173

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a “Aplicativo disponível” feature card on the About page with links to download the app from Google Play, F-Droid, and the official APK.

* **Bug Fixes**
  * Corrected an HTML nesting issue by closing an unclosed container to ensure proper layout and rendering.

* **Style**
  * Adjusted formatting to maintain consistent alignment of SVG tag closures and surrounding markup for readability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->