### PR TITLE
Add documentation feature card to website

### DIFF
--- a/Website About/NEW/index.html
+++ b/Website About/NEW/index.html
@@ -295,6 +295,14 @@
                   <h3 class="text-xl font-semibold text-gray-800 mb-3">Aplicativo disponível</h3>
                   <p class="text-gray-600">Use o ErikrafT Drop como app dedicado baixando pela <a href="https://play.google.com/store/apps/details?id=com.erikraft.drop" target="_blank" rel="noopener noreferrer" style="color: #2563eb;">Google Play</a>, instalando via <a href="https://f-droid.org/en/packages/com.erikraft.drop/" target="_blank" rel="noopener noreferrer" style="color: #2563eb;">F-Droid</a> ou baixando o <a href="https://github.com/erikraft/Drop-Android/releases/latest/download/Drop-Android.apk" target="_blank" rel="noopener noreferrer" style="color: #2563eb;">APK oficial</a> para acessar o ErikrafT Drop de forma fácil e rápida.</p>
                </div>
+               <!-- Feature 10 -->
+               <div class="feature-card bg-white p-8 rounded-xl shadow-md transition-all duration-300">
+                  <div class="w-14 h-14 bg-indigo-100 rounded-full flex items-center justify-center mb-6">
+                     <i class="fa-solid fa-book text-indigo-600 text-3xl"></i>
+                  </div>
+                  <h3 class="text-xl font-semibold text-gray-800 mb-3">Documentação completa</h3>
+                  <p class="text-gray-600">Aprenda a tirar o máximo do ErikrafT Drop com a <a href="https://deepwiki.com/erikraft/Drop" target="_blank" rel="noopener noreferrer" style="color: #2563eb;">documentação oficial</a> e explore os detalhes do app Android em <a href="https://deepwiki.com/erikraft/Drop-Android" target="_blank" rel="noopener noreferrer" style="color: #2563eb;">Drop-Android</a>, tudo sempre atualizado e fácil de consultar.</p>
+               </div>
             </div>
          </div>
       </section>


### PR DESCRIPTION
## Summary
- add a new feature card highlighting the official documentation resources
- link to the Drop and Drop-Android documentation pages with consistent styling

## Testing
- no tests were run (not applicable)

------
https://chatgpt.com/codex/tasks/task_e_68e8668f4498832ab37b407cff395e13

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a new feature card titled “Documentação completa” to the features grid, expanding it from 9 to 10 items. The card includes an icon, title, and description, offering quick access to official documentation and related app details.

* **Documentation**
  * Introduced prominent links to official documentation and app information directly from the features section, improving discoverability and ease of navigation for users.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->