### PR TITLE
Fix mobile zoom on About site

### DIFF
--- a/Website About/NEW/index.html
+++ b/Website About/NEW/index.html
@@ -124,11 +124,11 @@
          border: 0;
          }
          /* Estilo para telas menores que 600px (mobile) */
-         @media (max-width: 600px) {
-         body {
-         width: 400px;
-         height: 600px;
-         }
+        @media (max-width: 600px) {
+        body {
+        width: 100%;
+        height: auto;
+        }
          .iframe-container {
          padding-top: 0;
          width: 100%;


### PR DESCRIPTION
## Summary
- adjust the mobile media query so the body no longer forces a fixed width and height
- rely on the natural viewport sizing to avoid unintended zooming when the page loads

## Testing
- not run (not applicable)


------
https://chatgpt.com/codex/tasks/task_e_68e8698758b8832a8777ef07df5a049a

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * Improved mobile responsiveness by switching to a fluid layout on small screens. Content now adapts to device width, reducing horizontal scrolling and ensuring better readability and fit within the viewport. Iframe sections continue to behave correctly under the updated responsive rules.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->