### PR TITLE
Add minimize toggle to webchat sidebar

### DIFF
--- a/public/index.html
+++ b/public/index.html
@@ -167,12 +167,13 @@
             </svg>
         </div>
 
-<div id="webchat" class="icon-button" data-i18n-key="header.webchat" data-i18n-attrs="title" title="WebChat">
-    <a href="https://webchat.erikraft.com/" target="_blank">
-        <i class="fa-solid fa-message" aria-hidden="true"
-           style="font-size: 20px; width: 20px; height: 20px;"></i>
-    </a>
-</div>
+        <div id="webchat" class="icon-button" data-i18n-key="header.webchat" data-i18n-attrs="title" title="WebChat">
+            <a id="webchat-launcher" href="https://webchat.erikraft.com/" target="_blank" rel="noopener noreferrer"
+               aria-label="WebChat">
+                <i class="fa-solid fa-message" aria-hidden="true"
+                   style="font-size: 20px; width: 20px; height: 20px;"></i>
+            </a>
+        </div>
 
 	<div id="wetransfer" class="icon-button" data-i18n-key="header.wetransfer" data-i18n-attrs="title" title="WeTransfer">
 	    <a href="https://wetransfer.com/" target="_blank">
@@ -1159,7 +1160,222 @@
             <path d="M256 0c4.6 0 9.2 1 13.4 2.9L457.7 82.8c22 9.3 38.4 31 38.3 57.2c-.5 99.2-41.3 280.7-213.6 363.2c-16.7 8-36.1 8-52.8 0C57.3 420.7 16.5 239.2 16 140c-.1-26.2 16.3-47.9 38.3-57.2L242.7 2.9C246.8 1 251.4 0 256 0zm0 66.8V444.8C394 378 431.1 230.1 432 141.4L256 66.8l0 0z"></path>
         </symbol>
     </svg>
+    <div id="webchat-modal" class="webchat-modal" hidden aria-hidden="true" role="dialog" aria-modal="true"
+         aria-labelledby="webchat-modal-title">
+        <div class="webchat-modal__dialog" role="document">
+            <div class="webchat-modal__header">
+                <h2 id="webchat-modal-title">WebChat</h2>
+                <div class="webchat-modal__controls">
+                    <button type="button" class="webchat-modal__icon-button" data-webchat-minimize
+                            aria-label="Minimizar">
+                        ▬
+                    </button>
+                    <button type="button" class="webchat-modal__icon-button webchat-modal__close" data-webchat-close
+                            aria-label="Fechar">
+                        ✕
+                    </button>
+                </div>
+            </div>
+            <div class="webchat-modal__body">
+                <iframe id="webchat-frame" title="WebChat" loading="lazy" allow="camera; microphone"
+                        referrerpolicy="no-referrer"></iframe>
+            </div>
+            <div class="webchat-modal__footer">
+                <a class="btn btn-rounded webchat-modal__external" href="https://webchat.erikraft.com/" target="_blank"
+                   rel="noopener noreferrer">Ir para o site</a>
+            </div>
+        </div>
+    </div>
+    <button type="button" class="webchat-modal__restore" data-webchat-restore aria-label="Reabrir WebChat" hidden>
+        <span class="webchat-modal__restore-title">WebChat</span>
+    </button>
+
     <!-- Scripts -->
+
+    <script>
+        (function () {
+            const WEBCHAT_URL = 'https://webchat.erikraft.com/';
+            const launcher = document.getElementById('webchat-launcher');
+            const modal = document.getElementById('webchat-modal');
+            const iframe = document.getElementById('webchat-frame');
+            const closeButtons = modal ? modal.querySelectorAll('[data-webchat-close]') : [];
+            const minimizeButton = modal ? modal.querySelector('[data-webchat-minimize]') : null;
+            const restoreButton = document.querySelector('[data-webchat-restore]');
+            const dialog = modal ? modal.querySelector('.webchat-modal__dialog') : null;
+            const mobileMatcher = window.matchMedia('(max-width: 767px)');
+            let lastFocusedElement = null;
+
+            if (!launcher || !modal || !iframe || !dialog) {
+                return;
+            }
+
+            const setModalVisibility = (visible) => {
+                if (visible) {
+                    modal.hidden = false;
+                    modal.setAttribute('aria-hidden', 'false');
+                    modal.setAttribute('aria-modal', 'true');
+                    document.body.classList.add('webchat-modal-open');
+                    if (restoreButton) {
+                        restoreButton.hidden = true;
+                    }
+                    modal.classList.remove('webchat-modal--minimized');
+                    if (dialog) {
+                        dialog.removeAttribute('aria-hidden');
+                    }
+                }
+                else {
+                    modal.hidden = true;
+                    modal.setAttribute('aria-hidden', 'true');
+                    modal.setAttribute('aria-modal', 'false');
+                    document.body.classList.remove('webchat-modal-open');
+                    if (restoreButton) {
+                        restoreButton.hidden = true;
+                    }
+                    modal.classList.remove('webchat-modal--minimized');
+                    if (dialog) {
+                        dialog.removeAttribute('aria-hidden');
+                    }
+                }
+            };
+
+            const handleEscape = (event) => {
+                if (event.key === 'Escape') {
+                    event.preventDefault();
+                    closeModal();
+                }
+            };
+
+            const openModal = () => {
+                lastFocusedElement = document.activeElement;
+                if (!iframe.src) {
+                    iframe.src = WEBCHAT_URL;
+                }
+
+                setModalVisibility(true);
+                document.addEventListener('keydown', handleEscape);
+
+                const closeButton = modal.querySelector('.webchat-modal__close');
+                if (closeButton) {
+                    closeButton.focus({preventScroll: true});
+                }
+            };
+
+            const closeModal = () => {
+                if (modal.hidden) {
+                    return;
+                }
+
+                setModalVisibility(false);
+                document.removeEventListener('keydown', handleEscape);
+
+                if (lastFocusedElement && typeof lastFocusedElement.focus === 'function' &&
+                    !(lastFocusedElement instanceof Element && lastFocusedElement.hasAttribute('hidden'))) {
+                    lastFocusedElement.focus({preventScroll: true});
+                }
+            };
+
+            const minimizeModal = () => {
+                if (modal.hidden || modal.classList.contains('webchat-modal--minimized')) {
+                    return;
+                }
+
+                modal.classList.add('webchat-modal--minimized');
+                modal.hidden = false;
+                modal.setAttribute('aria-hidden', 'true');
+                modal.setAttribute('aria-modal', 'false');
+                document.body.classList.remove('webchat-modal-open');
+                if (dialog) {
+                    dialog.setAttribute('aria-hidden', 'true');
+                }
+
+                document.removeEventListener('keydown', handleEscape);
+
+                if (restoreButton) {
+                    restoreButton.hidden = false;
+                    restoreButton.focus({preventScroll: true});
+                }
+            };
+
+            const restoreModal = () => {
+                if (!modal.classList.contains('webchat-modal--minimized')) {
+                    return;
+                }
+
+                modal.classList.remove('webchat-modal--minimized');
+                modal.hidden = false;
+                modal.setAttribute('aria-hidden', 'false');
+                modal.setAttribute('aria-modal', 'true');
+                if (restoreButton) {
+                    restoreButton.hidden = true;
+                }
+                if (dialog) {
+                    dialog.removeAttribute('aria-hidden');
+                }
+
+                document.body.classList.add('webchat-modal-open');
+                document.addEventListener('keydown', handleEscape);
+
+                const closeButton = modal.querySelector('.webchat-modal__close');
+                if (closeButton) {
+                    closeButton.focus({preventScroll: true});
+                }
+            };
+
+            launcher.addEventListener('click', (event) => {
+                if (mobileMatcher.matches) {
+                    return;
+                }
+
+                event.preventDefault();
+                openModal();
+            });
+
+            closeButtons.forEach((button) => {
+                button.addEventListener('click', closeModal);
+            });
+
+            if (minimizeButton) {
+                minimizeButton.addEventListener('click', (event) => {
+                    event.preventDefault();
+                    minimizeModal();
+                });
+            }
+
+            if (restoreButton) {
+                restoreButton.addEventListener('click', (event) => {
+                    event.preventDefault();
+                    restoreModal();
+                });
+            }
+
+            modal.addEventListener('click', (event) => {
+                if (modal.classList.contains('webchat-modal--minimized')) {
+                    return;
+                }
+
+                if (event.target === modal) {
+                    closeModal();
+                }
+            });
+
+            dialog.addEventListener('click', (event) => {
+                event.stopPropagation();
+            });
+
+            const handleMobileChange = (event) => {
+                if (event.matches) {
+                    closeModal();
+                }
+            };
+
+            if (typeof mobileMatcher.addEventListener === 'function') {
+                mobileMatcher.addEventListener('change', handleMobileChange);
+            }
+            else if (typeof mobileMatcher.addListener === 'function') {
+                mobileMatcher.addListener(handleMobileChange);
+            }
+        })();
+    </script>
 
   <!-- Script de Instalação PWA -->
   <script>

--- a/public/styles/styles-main.css
+++ b/public/styles/styles-main.css
@@ -665,6 +665,201 @@ x-dialog:not([show]) x-background {
     opacity: 0.4;
 }
 
+.webchat-modal {
+    position: fixed;
+    inset: 0;
+    display: flex;
+    align-items: stretch;
+    justify-content: flex-end;
+    padding: 24px;
+    background-color: rgba(var(--shadow-color-dialog-cover-rgb, 0, 0, 0), 0.6);
+    z-index: 1000;
+}
+
+.webchat-modal[hidden] {
+    display: none;
+}
+
+body.webchat-modal-open {
+    overflow: hidden;
+}
+
+.webchat-modal__dialog {
+    display: flex;
+    flex-direction: column;
+    width: min(480px, 100%);
+    max-height: 100%;
+    margin-left: auto;
+    background-color: var(--dialog-bg-color);
+    color: rgb(var(--text-color));
+    border-radius: 20px;
+    box-shadow: 0 24px 48px rgba(var(--shadow-color-dialog-rgb, 0, 0, 0), 0.3);
+    overflow: hidden;
+}
+
+.webchat-modal__header,
+.webchat-modal__footer {
+    display: flex;
+    align-items: center;
+    justify-content: space-between;
+    gap: 12px;
+    padding: 16px 20px;
+}
+
+.webchat-modal__header {
+    border-bottom: 1px solid rgba(var(--shadow-color-dialog-rgb, 0, 0, 0), 0.12);
+}
+
+.webchat-modal__footer {
+    border-top: 1px solid rgba(var(--shadow-color-dialog-rgb, 0, 0, 0), 0.12);
+    justify-content: center;
+}
+
+.webchat-modal__header h2 {
+    margin: 0;
+    font-size: 18px;
+    font-weight: 600;
+}
+
+.webchat-modal__controls {
+    display: flex;
+    align-items: center;
+    gap: 8px;
+}
+
+.webchat-modal__body {
+    flex: 1;
+    display: flex;
+    min-height: 0;
+}
+
+.webchat-modal__body iframe {
+    flex: 1;
+    width: 100%;
+    border: none;
+    background-color: var(--dialog-bg-color);
+}
+
+.webchat-modal__icon-button {
+    display: inline-flex;
+    align-items: center;
+    justify-content: center;
+    width: 36px;
+    height: 36px;
+    border-radius: 50%;
+    border: none;
+    background-color: rgba(var(--text-color), 0.08);
+    color: rgb(var(--text-color));
+    font-size: 16px;
+    line-height: 1;
+    cursor: pointer;
+    transition: background-color 200ms;
+    font-family: inherit;
+}
+
+.webchat-modal__icon-button:hover,
+.webchat-modal__icon-button:focus {
+    background-color: rgba(var(--text-color), 0.16);
+}
+
+.webchat-modal__icon-button:focus {
+    outline: none;
+    box-shadow: 0 0 0 2px rgba(var(--accent-color), 0.35);
+}
+
+.webchat-modal__close {
+    font-size: 18px;
+}
+
+.webchat-modal__restore {
+    position: fixed;
+    right: 24px;
+    bottom: 24px;
+    display: inline-flex;
+    align-items: center;
+    gap: 10px;
+    padding: 12px 18px;
+    border: none;
+    border-radius: 16px;
+    background-color: var(--dialog-bg-color);
+    color: rgb(var(--text-color));
+    box-shadow: 0 16px 32px rgba(var(--shadow-color-dialog-rgb, 0, 0, 0), 0.25);
+    font-size: 15px;
+    font-weight: 600;
+    cursor: pointer;
+    transition: transform 150ms ease, box-shadow 150ms ease;
+}
+
+.webchat-modal__restore[hidden] {
+    display: none !important;
+}
+
+.webchat-modal__restore:hover,
+.webchat-modal__restore:focus {
+    transform: translateY(-1px);
+    box-shadow: 0 20px 36px rgba(var(--shadow-color-dialog-rgb, 0, 0, 0), 0.3);
+}
+
+.webchat-modal__restore:focus {
+    outline: none;
+    box-shadow: 0 0 0 2px rgba(var(--accent-color), 0.35), 0 20px 36px rgba(var(--shadow-color-dialog-rgb, 0, 0, 0), 0.3);
+}
+
+.webchat-modal__restore-title {
+    line-height: 1;
+}
+
+@media (max-width: 768px) {
+    .webchat-modal__restore {
+        right: 16px;
+        bottom: 16px;
+        padding: 10px 16px;
+        border-radius: 14px;
+    }
+}
+
+.webchat-modal--minimized {
+    inset: auto;
+    bottom: 24px;
+    right: 24px;
+    left: auto;
+    top: auto;
+    width: auto;
+    height: auto;
+    padding: 0;
+    background-color: transparent;
+    display: flex;
+    flex-direction: column;
+    align-items: stretch;
+    justify-content: flex-end;
+}
+
+.webchat-modal--minimized .webchat-modal__dialog {
+    display: none;
+}
+
+
+.webchat-modal__external {
+    width: 100%;
+    justify-content: center;
+    font-size: 14px;
+    font-weight: 600;
+    text-transform: none;
+    letter-spacing: normal;
+    padding: 10px 16px;
+}
+
+@media (max-width: 1024px) {
+    .webchat-modal {
+        padding: 16px;
+    }
+
+    .webchat-modal__dialog {
+        border-radius: 16px;
+        width: min(420px, 100%);
+    }
+}
+
 .btn-round {
     border-radius: 50%;
 }


### PR DESCRIPTION
## Summary
- add a minimize button beside the close control and expose a floating “WebChat” restore shortcut when collapsed
- extend the modal script to manage minimize/restore state, aria attributes, and focus handling
- update the modal styles for the new controls and minimized presentation while keeping the desktop sidebar alignment

## Testing
- npm start

------
https://chatgpt.com/codex/tasks/task_e_68eef43585ac832a842117c6e809f78c

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Introduced a WebChat experience launched from a new button, opening in a modal with header, body, and footer.
  * Added minimize/restore controls and a footer link to the WebChat site.
  * Implemented lazy-loading of the chat content for faster initial loads.

* **Improvements**
  * Enhanced accessibility: keyboard navigation, Escape-to-close, focus return, and improved screen reader support.
  * Responsive behavior refined for mobile to prevent intrusive modal display.
  * Added comprehensive modal styling with overlay, dialog, and embedded chat area.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->