### PR TITLE
Potential fix for code scanning alert no. 8: Client-side cross-site scripting

### DIFF
--- a/public/scripts/ui.js
+++ b/public/scripts/ui.js
@@ -3958,7 +3958,15 @@ class ChatUI {
         const meta = document.createElement('div');
         meta.className = 'chat-meta';
         const time = new Date(message.timestamp).toLocaleTimeString([], { hour: '2-digit', minute: '2-digit' });
-        meta.innerHTML = `<span>${message.senderName || message.senderId}</span><span>${time}</span>`;
+
+        const nameSpan = document.createElement('span');
+        nameSpan.innerText = message.senderName || message.senderId;
+
+        const timeSpan = document.createElement('span');
+        timeSpan.innerText = time;
+
+        meta.appendChild(nameSpan);
+        meta.appendChild(timeSpan);
 
         const body = document.createElement('div');
         body.className = 'chat-body';


### PR DESCRIPTION
Potential fix for [https://github.com/erikraft/Drop/security/code-scanning/8](https://github.com/erikraft/Drop/security/code-scanning/8)

In general, the problem is that untrusted text (`message.senderName` / `message.senderId`) is interpolated into a string and assigned to `meta.innerHTML`, which parses it as HTML. To fix this without changing functionality, we should avoid using `innerHTML` for untrusted data and instead build the DOM structure using `createElement` + `textContent`/`innerText` (which do not interpret HTML). This preserves the same visual structure (`<span>name</span><span>time</span>`) while eliminating XSS.

Concretely, in `public/scripts/ui.js` inside `_appendMessageNode`, replace the line

```js
meta.innerHTML = `<span>${message.senderName || message.senderId}</span><span>${time}</span>`;
```

with code that creates two `<span>` elements, sets their `.innerText` (or `.textContent`) to the sender label and time string, and appends them to `meta`. No new imports are needed, and no other parts of the code need to change, because the DOM structure will remain equivalent, just constructed safely.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Improved the internal structure of chat metadata rendering to enhance code maintainability and safety while preserving the display of sender name and timestamp information.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->