### PR TITLE
Fix infinite loading by restoring WebSocket server setup

### DIFF
--- a/server/server.js
+++ b/server/server.js
@@ -5,6 +5,7 @@ import path, {dirname} from "path";
 import http from "http";
 import multer from "multer";
 import {handleAiImageRequest} from "./services/ai-image.js";
+import ErikrafTdropWsServer from "./ws-server.js";
 
 // Ensure fetch/FormData/File exist for runtimes without native support (Node < 18)
 if (typeof fetch === "undefined" || typeof FormData === "undefined" || typeof File === "undefined") {
@@ -143,6 +144,14 @@ export default class ErikrafTdropServer {
         const hostname = conf.localhostOnly ? '127.0.0.1' : null;
         // Create HTTP server
         this.server = http.createServer(app);
+
+        // Initialize WebSocket server
+        this.wsServer = new ErikrafTdropWsServer(this.server, {
+            rtcConfig: conf.rtcConfig || { iceServers: [] },
+            wsFallback: conf.wsFallback || false,
+            debugMode: conf.debugMode || false,
+            rateLimit: conf.rateLimit || 1
+        });
 
         // Start listening
         this.server.listen(conf.port, hostname, () => {


### PR DESCRIPTION
### Motivation
- Restore the signaling WebSocket server that was accidentally removed so the client can establish signaling connections and exit the infinite-loading state for transfers.

### Description
- Re-added `ErikrafTdropWsServer` import and re-initialized the WebSocket server in `server/server.js` using the existing runtime options (`rtcConfig`, `wsFallback`, `debugMode`, `rateLimit`).

### Testing
- Ran `node --check server/server.js` and `node --check public/scripts/network.js` which passed, and started the app with `npm run start` which booted the server successfully (process was stopped by the CI timeout after verification).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e58bfad16c832aa6666e2da4d89298)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * WebSocket server integration with configurable options for rate limiting and debug mode support.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->