### PR TITLE
Align server bootstrap with PairDrop WebSocket architecture

### DIFF
--- a/server/server.js
+++ b/server/server.js
@@ -5,7 +5,6 @@ import path, {dirname} from "path";
 import http from "http";
 import multer from "multer";
 import {handleAiImageRequest} from "./services/ai-image.js";
-import ErikrafTdropWsServer from "./ws-server.js";
 
 // Ensure fetch/FormData/File exist for runtimes without native support (Node < 18)
 if (typeof fetch === "undefined" || typeof FormData === "undefined" || typeof File === "undefined") {
@@ -142,23 +141,14 @@ export default class ErikrafTdropServer {
         });
 
         const hostname = conf.localhostOnly ? '127.0.0.1' : null;
-        // Create HTTP server
-        this.server = http.createServer(app);
+        const server = http.createServer(app);
+        this.server = server;
 
-        // Initialize WebSocket server
-        this.wsServer = new ErikrafTdropWsServer(this.server, {
-            rtcConfig: conf.rtcConfig || { iceServers: [] },
-            wsFallback: conf.wsFallback || false,
-            debugMode: conf.debugMode || false,
-            rateLimit: conf.rateLimit || 1
-        });
-
-        // Start listening
-        this.server.listen(conf.port, hostname, () => {
+        server.listen(conf.port, hostname, () => {
             console.log(`Server running at http://${hostname}:${conf.port}/`);
         });
 
-        this.server.on('error', (err) => {
+        server.on('error', (err) => {
             if (err.code === 'EADDRINUSE') {
                 console.error(err);
                 console.info("Error EADDRINUSE received, exiting process without restarting process...");


### PR DESCRIPTION
### Motivation

- Match PairDrop's architecture by centralizing WebSocket signaling bootstrap in the main entrypoint and keep the HTTP server class focused on Express lifecycle.
- Prevent duplicate WebSocket initialization and potential conflicts when the bootstrap already starts the signaling server.

### Description

- Removed the `ErikrafTdropWsServer` import and WebSocket initialization from `server/server.js` so the class no longer constructs a signaling server.
- Exposed the underlying HTTP server on `this.server` by creating a local `server` variable and assigning it to `this.server`.
- Kept the HTTP listen and error handling behavior intact while leaving WebSocket startup to `server/index.js` which conditionally initializes the signaling server when `SIGNALING_SERVER` is not configured.

### Testing

- Ran `node --check server/server.js` which completed with no syntax errors.
- Ran `node --check server/index.js` which completed with no syntax errors.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e6b4656180832a9346737c815a9c98)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Changes**
  * Removed WebSocket server initialization, disabling real-time communication and RTC signaling capabilities. Server startup and HTTP lifecycle management have been streamlined.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->