### PR TITLE
Restore reconnect on navigator.connection changes in public/scripts/network.js

### DIFF
--- a/public/scripts/network.js
+++ b/public/scripts/network.js
@@ -9,6 +9,10 @@ class ServerConnection {
         Events.on('pagehide', _ => this._disconnect());
         Events.on(window.visibilityChangeEvent, _ => this._onVisibilityChange());
 
+        if (navigator.connection) {
+            navigator.connection.addEventListener('change', _ => this._reconnect());
+        }
+
         Events.on('room-secrets', e => this.send({ type: 'room-secrets', roomSecrets: e.detail }));
         Events.on('join-ip-room', _ => this.send({ type: 'join-ip-room'}));
         Events.on('room-secrets-deleted', e => this.send({ type: 'room-secrets-deleted', roomSecrets: e.detail}));


### PR DESCRIPTION
### Motivation
- The network change listener for connection-type changes was missing from `ServerConnection`, causing the client to miss reconnection triggers when the browser reports a network change; restoring it brings behavior back in line with upstream PairDrop.

### Description
- Add a conditional `navigator.connection` listener in the `ServerConnection` constructor that calls `this._reconnect()` on the `change` event (`if (navigator.connection) { navigator.connection.addEventListener('change', _ => this._reconnect()); }`).

### Testing
- Ran `node --check public/scripts/network.js` and it completed successfully.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e6b7c1958c832a8546abd9b8eecea9)