### PR TITLE
Harden UI initialization, fix NoSleep & WebChat binding, and refresh badges on peer updates

### DIFF
--- a/public/scripts/localization.js
+++ b/public/scripts/localization.js
@@ -195,8 +195,8 @@ class Localization {
 
             if (useDefault || Localization.currentLocaleIsDefault()) {
                 // Is default locale already
-                // Use empty string as translation
-                translation = ""
+                // Use key as translation fallback to keep UI stable and debuggable
+                translation = key;
             }
             else {
                 // Is not default locale yet

--- a/public/scripts/main.js
+++ b/public/scripts/main.js
@@ -45,6 +45,10 @@ class ErikrafTdrop {
     }
 
     async initialize() {
+        if (document.readyState === 'loading') {
+            await new Promise(resolve => document.addEventListener('DOMContentLoaded', resolve, { once: true }));
+        }
+
         this.registerServiceWorker();
 
         let startupError = null;
@@ -84,27 +88,38 @@ class ErikrafTdrop {
     }
 
     async hydrateUI() {
-        this.aboutUI = new AboutUI();
-        this.peersUI = new PeersUI();
-        this.languageSelectDialog = new LanguageSelectDialog();
-        this.receiveFileDialog = new ReceiveFileDialog();
-        this.receiveRequestDialog = new ReceiveRequestDialog();
-        this.sendTextDialog = new SendTextDialog();
-        this.receiveTextDialog = new ReceiveTextDialog();
-        this.pairDeviceDialog = new PairDeviceDialog();
-        this.clearDevicesDialog = new EditPairedDevicesDialog();
-        this.publicRoomDialog = new PublicRoomDialog();
-        this.lanModeDialog = new LanModeDialog();
-        this.base64Dialog = new Base64Dialog();
-        this.shareTextDialog = new ShareTextDialog();
-        this.toast = new Toast();
-        this.notifications = new Notifications();
-        this.networkStatusUI = new NetworkStatusUI();
-        this.webShareTargetUI = new WebShareTargetUI();
-        this.webFileHandlersUI = new WebFileHandlersUI();
-        this.noSleepUI = new NoSleepUI();
-        this.chatUI = new ChatUI();
-        this.broadCast = new BrowserTabsConnector();
+        const uiFactories = [
+            ['aboutUI', () => new AboutUI()],
+            ['peersUI', () => new PeersUI()],
+            ['languageSelectDialog', () => new LanguageSelectDialog()],
+            ['receiveFileDialog', () => new ReceiveFileDialog()],
+            ['receiveRequestDialog', () => new ReceiveRequestDialog()],
+            ['sendTextDialog', () => new SendTextDialog()],
+            ['receiveTextDialog', () => new ReceiveTextDialog()],
+            ['pairDeviceDialog', () => new PairDeviceDialog()],
+            ['clearDevicesDialog', () => new EditPairedDevicesDialog()],
+            ['publicRoomDialog', () => new PublicRoomDialog()],
+            ['lanModeDialog', () => new LanModeDialog()],
+            ['base64Dialog', () => new Base64Dialog()],
+            ['shareTextDialog', () => new ShareTextDialog()],
+            ['toast', () => new Toast()],
+            ['notifications', () => new Notifications()],
+            ['networkStatusUI', () => new NetworkStatusUI()],
+            ['webShareTargetUI', () => new WebShareTargetUI()],
+            ['webFileHandlersUI', () => new WebFileHandlersUI()],
+            ['noSleepUI', () => new NoSleepUI()],
+            ['chatUI', () => new ChatUI()],
+            ['broadCast', () => new BrowserTabsConnector()]
+        ];
+
+        uiFactories.forEach(([key, factory]) => {
+            try {
+                this[key] = factory();
+            } catch (error) {
+                this[key] = null;
+                console.error(`[App] Failed to initialize ${key}.`, error);
+            }
+        });
 
         this.contentModeration = await this.createContentModeration();
     }

--- a/public/scripts/ui.js
+++ b/public/scripts/ui.js
@@ -2036,10 +2036,12 @@ class PairDeviceDialog extends Dialog {
         message.peers.forEach(messagePeer => {
             this._evaluateJoinedPeer(messagePeer.id, message.roomType, message.roomId);
         });
+        Events.fire('evaluate-footer-badges');
     }
 
     _onPeerJoined(message) {
         this._evaluateJoinedPeer(message.peer.id, message.roomType, message.roomId);
+        Events.fire('evaluate-footer-badges');
     }
 
     _evaluateJoinedPeer(peerId, roomType, roomId) {
@@ -2464,10 +2466,12 @@ class PublicRoomDialog extends Dialog {
         message.peers.forEach(messagePeer => {
             this._evaluateJoinedPeer(messagePeer.id, message.roomId);
         });
+        Events.fire('evaluate-footer-badges');
     }
 
     _onPeerJoined(message) {
         this._evaluateJoinedPeer(message.peer.id, message.roomId);
+        Events.fire('evaluate-footer-badges');
     }
 
     _evaluateJoinedPeer(peerId, roomId) {
@@ -2542,11 +2546,12 @@ class LanModeDialog extends Dialog {
 
         this._ipPeers = new Set();
         this._wsConnected = false;
+        this._initialized = !!(this.$el && this.$headerBtn && this.$toggle && this.$serverInput && this.$scanBtn && this.$applyBtn);
 
-        this.$headerBtn.addEventListener('click', _ => this.show());
-        this.$toggle.addEventListener('change', _ => this._applySettings());
-        this.$applyBtn.addEventListener('click', _ => this._applySettings());
-        this.$scanBtn.addEventListener('click', _ => this._scanCommonHosts());
+        if (this.$headerBtn) this.$headerBtn.addEventListener('click', _ => this.show());
+        if (this.$toggle) this.$toggle.addEventListener('change', _ => this._applySettings());
+        if (this.$applyBtn) this.$applyBtn.addEventListener('click', _ => this._applySettings());
+        if (this.$scanBtn) this.$scanBtn.addEventListener('click', _ => this._scanCommonHosts());
 
         Events.on('ws-connected', _ => this._onWsConnected());
         Events.on('ws-disconnected', _ => this._onWsDisconnected());
@@ -2555,16 +2560,23 @@ class LanModeDialog extends Dialog {
         Events.on('peer-left', e => this._onPeerLeft(e.detail));
         Events.on('translation-loaded', _ => this._updateStatus());
 
+        if (!this._initialized) {
+            console.warn('[LanModeDialog] Missing required DOM nodes. LAN mode UI will stay disabled.');
+            return;
+        }
+
         this._loadSettings();
         this._updateStatus();
     }
 
     show() {
+        if (!this._initialized) return;
         this._updateStatus();
         super.show();
     }
 
     _loadSettings() {
+        if (!this._initialized) return;
         let enabled = false;
         let server = '';
         try {
@@ -2581,6 +2593,7 @@ class LanModeDialog extends Dialog {
     }
 
     _applySettings() {
+        if (!this._initialized) return;
         const enabled = this.$toggle.checked;
         const server = (this.$serverInput.value || '').trim();
 
@@ -2674,6 +2687,7 @@ class LanModeDialog extends Dialog {
     }
 
     _updateStatus() {
+        if (!this._initialized) return;
         const enabled = this.$toggle.checked;
         if (!enabled) {
             if (this.$connectionStatus) this.$connectionStatus.textContent = '';
@@ -2686,6 +2700,7 @@ class LanModeDialog extends Dialog {
     }
 
     _updateLanBadges(enabled) {
+        if (!this.$lanBadges) return;
         this.$lanBadges.forEach(badge => {
             if (enabled) {
                 badge.removeAttribute('hidden');
@@ -2697,6 +2712,7 @@ class LanModeDialog extends Dialog {
     }
 
     async _scanCommonHosts() {
+        if (!this._initialized) return;
         if (location.protocol === 'https:') {
             Events.fire('notify-user', Localization.getTranslation("notifications.lan-https-blocked"));
             return;
@@ -3656,20 +3672,38 @@ class WebFileHandlersUI {
 
 class NoSleepUI {
     constructor() {
-        NoSleepUI._nosleep = new NoSleep();
+        try {
+            if (typeof NoSleep === 'function') {
+                NoSleepUI._nosleep = new NoSleep();
+            } else {
+                console.warn('[NoSleepUI] NoSleep library is unavailable.');
+                NoSleepUI._nosleep = null;
+            }
+        }
+        catch (error) {
+            console.warn('[NoSleepUI] Failed to initialize NoSleep.', error);
+            NoSleepUI._nosleep = null;
+        }
     }
 
     static enable() {
         if (!this._interval) {
+            if (!NoSleepUI._nosleep || typeof NoSleepUI._nosleep.enable !== 'function') {
+                return;
+            }
             NoSleepUI._nosleep.enable();
             NoSleepUI._interval = setInterval(() => NoSleepUI.disable(), 10000);
         }
     }
 
     static disable() {
+        if (!NoSleepUI._nosleep || typeof NoSleepUI._nosleep.disable !== 'function') {
+            return;
+        }
         if ($$('x-peer[status]') === null) {
             clearInterval(NoSleepUI._interval);
             NoSleepUI._nosleep.disable();
+            NoSleepUI._interval = null;
         }
     }
 }
@@ -3686,15 +3720,22 @@ class ChatUI {
         this.$uploadBtn = $('chat-upload');
         this.$uploadInput = $('chat-upload-input');
         this.$status = $('chat-room-status');
+        this.$footer = null;
+        this.$footerBadgeLocal = null;
+        this.$footerBadgePaired = null;
+        this.$footerBadgePublic = null;
+        this.$footerDiscovery = null;
+
+        if (!this.$panel || !this.$toggle || !this.$roomSelect || !this.$messages || !this.$form || !this.$input) {
+            console.warn('[ChatUI] Required DOM nodes are missing. Chat UI not initialized.');
+            return;
+        }
+
         this.$footer = this.$panel.querySelector('.chat-footer');
         this.$footerBadgeLocal = this.$panel.querySelector('.chat-footer .badge-room-ip');
         this.$footerBadgePaired = this.$panel.querySelector('.chat-footer .badge-room-secret');
         this.$footerBadgePublic = this.$panel.querySelector('.chat-footer .badge-room-public-id');
         this.$footerDiscovery = this.$panel.querySelector('.chat-footer .discovery-wrapper');
-
-        if (!this.$panel || !this.$toggle || !this.$roomSelect || !this.$messages || !this.$form || !this.$input) {
-            return;
-        }
 
         this._rooms = new Map();
         this._peerNames = new Map();
@@ -3704,7 +3745,10 @@ class ChatUI {
         this._selfDisplayName = '';
         this._defaultTitle = 'ErikrafT Drop | Transfer Files Cross-Platform. No Setup, No Signup.';
 
-        this.$toggle.addEventListener('click', _ => this.toggle());
+        this.$toggle.addEventListener('click', _ => {
+            console.debug('[ChatUI] WebChat toggle clicked.');
+            this.toggle();
+        });
         if (this.$close) {
             this.$close.addEventListener('click', _ => this.hide());
         }


### PR DESCRIPTION
### Motivation
- A constructor-time null dereference in `LanModeDialog` (missing DOM nodes) caused `addEventListener` to throw and abort full UI hydration, breaking WebChat and badge behavior. 
- `NoSleepUI` assumed the NoSleep library was always present, producing `undefined.enable` errors in some load/order scenarios. 
- Footer badges and pairing/public-room indicators could become stale because peer update handlers did not always trigger a badge reevaluation.

### Description
- Guarded `LanModeDialog` DOM access: added null-safe listener registration, an `_initialized` gate, and short-circuit checks in state/update methods to prevent constructor-time crashes when markup is absent. (modified `public/scripts/ui.js`).
- Made `NoSleepUI` resilient: wrapped NoSleep construction in try/catch, detect missing library, and guard `enable()`/`disable()` calls to avoid calling undefined functions. (modified `public/scripts/ui.js`).
- Hardened `ChatUI` initialization: defer/validate footer subqueries until required nodes exist, emit a debug log on WebChat toggle click to help diagnose handler execution, and avoid failing the whole hydration when chat DOM is missing. (modified `public/scripts/ui.js`).
- Safer app hydration: wait for `DOMContentLoaded` in `initialize()` and construct UI components via a per-component factory loop with try/catch so a single constructor failure no longer aborts all UI initialization. (modified `public/scripts/main.js`).
- Force badge refresh on peer updates: fire `evaluate-footer-badges` after `peers` and `peer-joined` events in PairDevice and PublicRoom flows to keep discovery/pairing badges in sync. (modified `public/scripts/ui.js`).
- More robust localization fallback: when default-locale lookup fails, return the key string instead of an empty string to avoid blank UI labels. (modified `public/scripts/localization.js`).

### Testing
- Ran syntax/type checks with `node --check public/scripts/ui.js`, `node --check public/scripts/main.js`, and `node --check public/scripts/localization.js`, and all checks passed successfully.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e770fb83fc832aa3ac06aa6711f67f)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Missing translations now display the translation key instead of appearing blank
  * Footer badges in peer dialogs refresh when peers join or status changes
  * Application initialization improved with proper DOM readiness handling before service startup
  * UI components enhanced with better error handling and graceful fallbacks during initialization
  * Added validation checks for dialogs to prevent initialization errors

<!-- end of auto-generated comment: release notes by coderabbit.ai -->