### PR TITLE
Unify discovery badge state across LAN/IP/paired/public channels

### DIFF
--- a/public/scripts/main.js
+++ b/public/scripts/main.js
@@ -3,8 +3,6 @@ class ErikrafTdrop {
     constructor() {
         this.$headerNotificationBtn = $('notification');
         this.$headerEditPairedDevicesBtn = $('edit-paired-devices');
-        this.$footerPairedDevicesBadge = $$('.discovery-wrapper .badge-room-secret');
-        this.$chatFooterPairedDevicesBadge = $$('#chat-panel .badge-room-secret');
         this.$headerInstallBtn = $('install');
 
         this.deferredStyles = [
@@ -212,8 +210,7 @@ class ErikrafTdrop {
         }
 
         this.$headerEditPairedDevicesBtn?.removeAttribute('hidden');
-        this.$footerPairedDevicesBadge?.removeAttribute('hidden');
-        this.$chatFooterPairedDevicesBadge?.removeAttribute('hidden');
+        Events.fire('room-secrets', roomSecrets);
     }
 
     async localizationSafeInit() {
@@ -224,6 +221,7 @@ class ErikrafTdrop {
         this.headerUI = new HeaderUI();
         this.centerUI = new CenterUI();
         this.footerUI = new FooterUI();
+        this.discoveryBadgeState = new DiscoveryBadgeState();
 
         await this.localization.setInitialTranslation();
     }

--- a/public/scripts/ui-main.js
+++ b/public/scripts/ui-main.js
@@ -2,6 +2,140 @@
 const $ = query => document.getElementById(query);
 const $$ = query => document.querySelector(query);
 
+function getDiscoveryState({ roomType, roomSecrets, publicRoomId }) {
+    const roomTypes = Array.isArray(roomType) ? roomType : [roomType];
+    return {
+        isLan: roomTypes.includes('lan'),
+        isIp: roomTypes.includes('ip'),
+        isPaired: Array.isArray(roomSecrets) && roomSecrets.length > 0,
+        publicRoomId: publicRoomId || null
+    };
+}
+
+function updateDiscoveryBadges(state) {
+    const { isLan, isIp, isPaired, publicRoomId } = state;
+
+    document.querySelectorAll('.badge-room-lan').forEach(el => {
+        el.hidden = !isLan;
+    });
+
+    document.querySelectorAll('.badge-room-ip').forEach(el => {
+        el.hidden = !isIp;
+    });
+
+    document.querySelectorAll('.badge-room-secret').forEach(el => {
+        el.hidden = !isPaired;
+    });
+
+    document.querySelectorAll('.badge-room-public-id').forEach(el => {
+        if (publicRoomId) {
+            el.hidden = false;
+            el.textContent = `na sala ${publicRoomId.toUpperCase()}`;
+        }
+        else {
+            el.hidden = true;
+        }
+    });
+
+    console.log('[Discovery State]', state);
+}
+
+class DiscoveryBadgeState {
+    constructor() {
+        this._activeRoomTypes = new Set();
+        this._roomSecrets = [];
+        this._publicRoomId = null;
+
+        Events.on('peers', e => this._onPeers(e.detail));
+        Events.on('peer-joined', e => this._onPeerJoined(e.detail));
+        Events.on('room-secrets', e => this._onRoomSecrets(e.detail));
+        Events.on('room-secrets-deleted', e => this._onRoomSecretsDeleted(e.detail));
+        Events.on('join-public-room', e => this._onJoinPublicRoom(e.detail));
+        Events.on('public-room-created', e => this._onPublicRoomCreated(e.detail));
+        Events.on('public-room-left', _ => this._onPublicRoomLeft());
+        Events.on('discovery-public-room-id', e => this._onPublicRoomCreated(e.detail));
+        Events.on('ws-disconnected', _ => this._onWsDisconnected());
+
+        this._initFromStorage();
+        this._render();
+    }
+
+    async _initFromStorage() {
+        this._publicRoomId = sessionStorage.getItem('public_room_id') || null;
+        if (typeof PersistentStorage !== 'undefined' && typeof PersistentStorage.getAllRoomSecrets === 'function') {
+            const roomSecrets = await PersistentStorage.getAllRoomSecrets();
+            this._roomSecrets = Array.isArray(roomSecrets) ? [...roomSecrets] : [];
+        }
+        this._render();
+    }
+
+    _onPeers(message) {
+        if (message?.roomType === 'lan' || message?.roomType === 'ip') {
+            this._activeRoomTypes.add(message.roomType);
+        }
+        if (message?.roomType === 'public-id' && message?.roomId) {
+            this._publicRoomId = message.roomId;
+        }
+        this._render();
+    }
+
+    _onPeerJoined(message) {
+        if (message?.roomType === 'lan' || message?.roomType === 'ip') {
+            this._activeRoomTypes.add(message.roomType);
+        }
+        if (message?.roomType === 'public-id' && message?.roomId) {
+            this._publicRoomId = message.roomId;
+        }
+        this._render();
+    }
+
+    _onRoomSecrets(roomSecrets) {
+        if (!Array.isArray(roomSecrets)) return;
+        const merged = new Set(this._roomSecrets);
+        roomSecrets.forEach(secret => merged.add(secret));
+        this._roomSecrets = Array.from(merged);
+        this._render();
+    }
+
+    _onRoomSecretsDeleted(roomSecrets) {
+        if (!Array.isArray(roomSecrets)) return;
+        this._roomSecrets = this._roomSecrets.filter(secret => !roomSecrets.includes(secret));
+        this._render();
+    }
+
+    _onJoinPublicRoom(detail) {
+        if (!detail?.roomId) return;
+        this._publicRoomId = detail.roomId;
+        this._render();
+    }
+
+    _onPublicRoomCreated(roomId) {
+        if (!roomId) return;
+        this._publicRoomId = roomId;
+        this._render();
+    }
+
+    _onPublicRoomLeft() {
+        this._publicRoomId = null;
+        this._render();
+    }
+
+    _onWsDisconnected() {
+        this._activeRoomTypes.clear();
+        this._render();
+    }
+
+    _render() {
+        const state = getDiscoveryState({
+            roomType: Array.from(this._activeRoomTypes),
+            roomSecrets: this._roomSecrets,
+            publicRoomId: this._publicRoomId
+        });
+        updateDiscoveryBadges(state);
+        Events.fire('evaluate-footer-badges');
+    }
+}
+
 // Event listener shortcuts
 class Events {
     static fire(type, detail = {}) {

--- a/public/scripts/ui.js
+++ b/public/scripts/ui.js
@@ -1896,8 +1896,6 @@ class PairDeviceDialog extends Dialog {
         super('pair-device-dialog');
         this.$pairDeviceHeaderBtn = $('pair-device');
         this.$editPairedDevicesHeaderBtn = $('edit-paired-devices');
-        this.$footerInstructionsPairedDevices = $$('.discovery-wrapper .badge-room-secret');
-        this.$chatFooterPairedDevices = $$('#chat-panel .badge-room-secret');
 
         this.$key = this.$el.querySelector('.key');
         this.$qrCode = this.$el.querySelector('.key-qr-code');
@@ -2123,18 +2121,13 @@ class PairDeviceDialog extends Dialog {
             .then(roomSecrets => {
                 if (roomSecrets.length > 0) {
                     this.$editPairedDevicesHeaderBtn.removeAttribute('hidden');
-                    this.$footerInstructionsPairedDevices.removeAttribute('hidden');
-                    if (this.$chatFooterPairedDevices) {
-                        this.$chatFooterPairedDevices.removeAttribute('hidden');
-                    }
+                    Events.fire('room-secrets', roomSecrets);
                 }
                 else {
                     this.$editPairedDevicesHeaderBtn.setAttribute('hidden', true);
-                    this.$footerInstructionsPairedDevices.setAttribute('hidden', true);
-                    if (this.$chatFooterPairedDevices) {
-                        this.$chatFooterPairedDevices.setAttribute('hidden', true);
-                    }
+                    Events.fire('room-secrets-deleted', this._roomSecretsCached || []);
                 }
+                this._roomSecretsCached = roomSecrets;
                 Events.fire('evaluate-footer-badges');
             });
     }
@@ -2144,10 +2137,12 @@ class EditPairedDevicesDialog extends Dialog {
     constructor() {
         super('edit-paired-devices-dialog');
         this.$pairedDevicesWrapper = this.$el.querySelector('.paired-devices-wrapper');
-        this.$footerBadgePairedDevices = $$('.discovery-wrapper .badge-room-secret');
+        this.$footerBadgePairedDevices = document.querySelectorAll('.discovery-wrapper .badge-room-secret');
 
         $('edit-paired-devices').addEventListener('click', _ => this._onEditPairedDevices());
-        this.$footerBadgePairedDevices.addEventListener('click', _ => this._onEditPairedDevices());
+        this.$footerBadgePairedDevices.forEach($badge => {
+            $badge.addEventListener('click', _ => this._onEditPairedDevices());
+        });
 
         Events.on('peer-display-name-changed', e => this._onPeerDisplayNameChanged(e));
         Events.on('keydown', e => this._onKeyDown(e));
@@ -2304,8 +2299,7 @@ class PublicRoomDialog extends Dialog {
         this.$leaveBtn = this.$el.querySelector('.leave-room');
         this.$joinSubmitBtn = this.$el.querySelector('button[type="submit"]');
         this.$headerBtnJoinPublicRoom = $('join-public-room');
-        this.$footerBadgePublicRoomDevices = $$('.discovery-wrapper .badge-room-public-id');
-        this.$chatFooterBadgePublicRoomDevices = $$('#chat-panel .badge-room-public-id');
+        this.$footerBadgePublicRoomDevices = document.querySelectorAll('.discovery-wrapper .badge-room-public-id');
 
 
         this.$form.addEventListener('submit', e => this._onSubmit(e));
@@ -2313,7 +2307,9 @@ class PublicRoomDialog extends Dialog {
         this.$leaveBtn.addEventListener('click', _ => this._leavePublicRoom())
 
         this.$headerBtnJoinPublicRoom.addEventListener('click', _ => this._onHeaderBtnClick());
-        this.$footerBadgePublicRoomDevices.addEventListener('click', _ => this._onHeaderBtnClick());
+        this.$footerBadgePublicRoomDevices.forEach($badge => {
+            $badge.addEventListener('click', _ => this._onHeaderBtnClick());
+        });
 
         this.inputKeyContainer = new InputKeyContainer(
             this.$el.querySelector('.input-key-container'),
@@ -2396,18 +2392,7 @@ class PublicRoomDialog extends Dialog {
 
     setFooterBadge() {
         if (!this.roomId) return;
-
-        this.$footerBadgePublicRoomDevices.innerText = Localization.getTranslation("footer.public-room-devices", null, {
-            roomId: this.roomId.toUpperCase()
-        });
-        this.$footerBadgePublicRoomDevices.removeAttribute('hidden');
-        if (this.$chatFooterBadgePublicRoomDevices) {
-            this.$chatFooterBadgePublicRoomDevices.innerText = Localization.getTranslation("footer.public-room-devices", null, {
-                roomId: this.roomId.toUpperCase()
-            });
-            this.$chatFooterBadgePublicRoomDevices.removeAttribute('hidden');
-        }
-
+        Events.fire('discovery-public-room-id', this.roomId);
         Events.fire('evaluate-footer-badges');
     }
 
@@ -2523,10 +2508,6 @@ class PublicRoomDialog extends Dialog {
         this.roomId = null;
         this.inputKeyContainer._cleanUp();
         sessionStorage.removeItem('public_room_id');
-        this.$footerBadgePublicRoomDevices.setAttribute('hidden', true);
-        if (this.$chatFooterBadgePublicRoomDevices) {
-            this.$chatFooterBadgePublicRoomDevices.setAttribute('hidden', true);
-        }
         Events.fire('evaluate-footer-badges');
     }
 }


### PR DESCRIPTION
### Motivation
- Badge visibility/state for discovery modes was scattered across multiple UI files and often updated a single DOM node, causing main/chat footer desync and preventing multiple discovery modes from showing simultaneously. 
- Centralize discovery badge logic so LAN, IP, paired and public-room modes can coexist and be reflected everywhere in the UI.

### Description
- Added a unified state builder and renderer: `getDiscoveryState(...)` and `updateDiscoveryBadges(...)` which update all matching badge nodes via `document.querySelectorAll(...)` and log state with `console.log('[Discovery State]', state)` in `public/scripts/ui-main.js`.
- Implemented `DiscoveryBadgeState` (in `public/scripts/ui-main.js`) which centralizes discovery state and listens to events: `peers`, `peer-joined`, `room-secrets`, `room-secrets-deleted`, `join-public-room`, `public-room-created`, `public-room-left`, `ws-disconnected` and initialization from `PersistentStorage`/`sessionStorage`, and triggers `updateDiscoveryBadges(...)` + `Events.fire('evaluate-footer-badges')`.
- Hooked startup and dialog logic into the unified flow: startup now fires `Events.fire('room-secrets', roomSecrets)` after loading stored secrets and instantiates `DiscoveryBadgeState` during UI init in `public/scripts/main.js`.
- Removed duplicated per-view DOM toggles and switched UI producers to emit shared events instead (updated `PairDeviceDialog` and `PublicRoomDialog` to emit `room-secrets`, `room-secrets-deleted`, and `discovery-public-room-id`), and replaced single-node `querySelector` usages with `querySelectorAll` for badge click bindings in `public/scripts/ui.js`.

### Testing
- Syntax checks: `node --check public/scripts/ui-main.js`, `node --check public/scripts/ui.js`, `node --check public/scripts/main.js` all completed successfully.
- No additional automated unit tests exist for runtime UI; runtime verification should confirm that the LAN, IP, paired and public badges can appear simultaneously in both the main footer and chat footer after these changes.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e77c7397b8832abd09423b36209d80)