### PR TITLE
Fix Discord slash command acknowledgements to avoid timeout errors

### DIFF
--- a/Discord/Bot/src/commands/drop.js
+++ b/Discord/Bot/src/commands/drop.js
@@ -102,7 +102,9 @@ export const data = new SlashCommandBuilder()
         option.setName('file3').setDescription('Third file (optional).'));
 
 export async function execute(interaction) {
-    await interaction.deferReply({ ephemeral: true });
+    if (!interaction.deferred && !interaction.replied) {
+        await interaction.deferReply({ ephemeral: true });
+    }
 
     const rawPairKey = interaction.options.getString('key', true);
     const pairKey = normalizePairKey(rawPairKey);

--- a/Discord/Bot/src/commands/receive.js
+++ b/Discord/Bot/src/commands/receive.js
@@ -77,7 +77,9 @@ export const data = new SlashCommandBuilder()
             .setMaxLength(64));
 
 export async function execute(interaction) {
-    await interaction.deferReply({ ephemeral: true });
+    if (!interaction.deferred && !interaction.replied) {
+        await interaction.deferReply({ ephemeral: true });
+    }
 
     const rawPairKey = interaction.options.getString('key', true);
     const pairKey = normalizePairKey(rawPairKey);

--- a/Discord/Bot/src/index.js
+++ b/Discord/Bot/src/index.js
@@ -42,19 +42,34 @@ async function main() {
         if (!interaction.isChatInputCommand()) return;
 
         const command = client.commands.get(interaction.commandName);
-        if (!command) return;
+        if (!command) {
+            await interaction.reply({
+                content: 'Esse comando não está disponível no momento. Tente registrar os comandos novamente.',
+                ephemeral: true
+            });
+            return;
+        }
 
         try {
+            if (!interaction.deferred && !interaction.replied) {
+                await interaction.deferReply({ ephemeral: true });
+            }
             await command.execute(interaction);
         }
         catch (error) {
             console.error(error);
             const content = 'Ocorreu um erro ao executar este comando.';
-            if (interaction.deferred || interaction.replied) {
-                await interaction.editReply({ content });
+
+            try {
+                if (interaction.deferred || interaction.replied) {
+                    await interaction.editReply({ content });
+                }
+                else {
+                    await interaction.reply({ content, ephemeral: true });
+                }
             }
-            else {
-                await interaction.reply({ content, ephemeral: true });
+            catch (responseError) {
+                console.error('Falha ao enviar resposta de erro da interação:', responseError);
             }
         }
     });


### PR DESCRIPTION
### Motivation
- Prevent the Discord client from showing "The application did not respond" when a slash command is invoked but not acknowledged or the command module is not loaded. 
- Make interaction error handling more defensive so failed replies/edit attempts do not leave the interaction unresolved.

### Description
- Added a fallback reply when a chat input command is not present in `client.commands` to avoid silently returning (file: `Discord/Bot/src/index.js`).
- Ensure interactions are acknowledged before command execution by deferring only when `!interaction.deferred && !interaction.replied` in the main handler (file: `Discord/Bot/src/index.js`).
- Hardened the interaction error path with a nested `try/catch` so response failures are logged and do not throw (file: `Discord/Bot/src/index.js`).
- Updated the `execute` handlers for `/drop` and `/receive` to call `deferReply` only when the interaction has not already been acknowledged (files: `Discord/Bot/src/commands/drop.js`, `Discord/Bot/src/commands/receive.js`).

### Testing
- Ran `node --check Discord/Bot/src/index.js` and it succeeded.
- Ran `node --check Discord/Bot/src/commands/drop.js` and it succeeded.
- Ran `node --check Discord/Bot/src/commands/receive.js` and it succeeded.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69ed18723ba0832ab47bccc95aff9328)