### PR TITLE
Configure Linux packaging icons

### DIFF
--- a/electron-builder.yml
+++ b/electron-builder.yml
@@ -17,7 +17,7 @@ linux:
       arch:
         - x64
   category: Network;Utility;
-  icon: public/images/icon-drop.svg
+  icon: packaging/linux/icons/icon-drop.svg
   desktop:
     Name: ErikrafT Drop
     Comment: File sharing by ErikrafT
@@ -27,7 +27,9 @@ linux:
     Categories: Network;Utility;
 deb:
   fpm:
-    - public/images/icon-drop.svg=/usr/share/icons/hicolor/scalable/apps/erikraft-drop.svg
+    - packaging/linux/icons/icon-drop.svg=/usr/share/icons/hicolor/scalable/apps/erikraft-drop.svg
+    - packaging/linux/icons/android-chrome-512x512.png=/usr/share/icons/hicolor/512x512/apps/erikraft-drop.png
+    - packaging/linux/icons/android-chrome-512x512-maskable.png=/usr/share/icons/hicolor/512x512/apps/erikraft-drop-maskable.png
   packageName: erikraft-drop
   depends:
     - libgtk-3-0

--- a/flatpak/io.github.erikraft.Drop.metainfo.xml
+++ b/flatpak/io.github.erikraft.Drop.metainfo.xml
@@ -7,7 +7,7 @@
   <summary>File sharing by ErikrafT</summary>
   <description>
     <p>ErikrafT Drop helps share files between nearby devices through a simple desktop window.</p>
-    <p>The Linux desktop integration uses the existing project SVG icon without generating derived binary icons.</p>
+    <p>The Linux desktop integration uses packaging/linux/icons/icon-drop.svg as the primary icon with the existing 512px PNG icons as fallbacks.</p>
   </description>
   <launchable type="desktop-id">io.github.erikraft.Drop.desktop</launchable>
   <categories>

--- a/flatpak/io.github.erikraft.Drop.yml
+++ b/flatpak/io.github.erikraft.Drop.yml
@@ -25,7 +25,9 @@ modules:
       - cp -a dist/desktop/linux-unpacked/. /app/erikraft-drop/
       - install -Dm644 flatpak/io.github.erikraft.Drop.desktop /app/share/applications/io.github.erikraft.Drop.desktop
       - install -Dm644 flatpak/io.github.erikraft.Drop.metainfo.xml /app/share/metainfo/io.github.erikraft.Drop.metainfo.xml
-      - install -Dm644 public/images/icon-drop.svg /app/share/icons/hicolor/scalable/apps/io.github.erikraft.Drop.svg
+      - install -Dm644 packaging/linux/icons/icon-drop.svg /app/share/icons/hicolor/scalable/apps/io.github.erikraft.Drop.svg
+      - install -Dm644 packaging/linux/icons/android-chrome-512x512.png /app/share/icons/hicolor/512x512/apps/io.github.erikraft.Drop.png
+      - install -Dm644 packaging/linux/icons/android-chrome-512x512-maskable.png /app/share/icons/hicolor/512x512/apps/io.github.erikraft.Drop-maskable.png
     sources:
       - type: dir
         path: ..

--- a/scripts/validate-linux-icon.js
+++ b/scripts/validate-linux-icon.js
@@ -2,7 +2,22 @@ import fs from 'fs/promises';
 import path from 'path';
 
 const root = process.cwd();
-const iconPath = path.join(root, 'public/images/icon-drop.svg');
+const linuxIcons = [
+  {
+    label: 'Primary Linux SVG icon',
+    path: 'packaging/linux/icons/icon-drop.svg',
+  },
+  {
+    label: 'Linux 512px PNG fallback icon',
+    path: 'packaging/linux/icons/android-chrome-512x512.png',
+  },
+  {
+    label: 'Linux 512px maskable PNG fallback icon',
+    path: 'packaging/linux/icons/android-chrome-512x512-maskable.png',
+  },
+];
 
-await fs.access(iconPath);
-console.log('Using existing SVG icon: public/images/icon-drop.svg');
+for (const icon of linuxIcons) {
+  await fs.access(path.join(root, icon.path));
+  console.log(`${icon.label}: ${icon.path}`);
+}


### PR DESCRIPTION
### Motivation
- Ensure the packaged Linux app (Deb, Flatpak) and desktop menu use the provided `packaging/linux/icons/icon-drop.svg` as the primary SVG and the existing 512px PNGs as fallbacks without creating or modifying binary icons.

### Description
- Point Electron packaging to `packaging/linux/icons/icon-drop.svg` by updating `electron-builder.yml` and keep desktop lookup name `erikraft-drop` for menu integration.
- Add `.deb` fpm mappings in `electron-builder.yml` to install `packaging/linux/icons/icon-drop.svg` and both `512x512` PNG fallbacks into hicolor icon locations.
- Update `flatpak/io.github.erikraft.Drop.yml` to install the primary SVG and the two existing PNG fallbacks into the Flatpak app icons directory and update `flatpak/io.github.erikraft.Drop.metainfo.xml` wording to reflect the new primary/fallback arrangement.
- Replace `scripts/validate-linux-icon.js` with validation that checks the presence of `packaging/linux/icons/icon-drop.svg`, `packaging/linux/icons/android-chrome-512x512.png`, and `packaging/linux/icons/android-chrome-512x512-maskable.png`.

### Testing
- Ran `npm run validate:linux-icon`, which succeeded and reported all three icons present.
- Attempted desktop metadata checks with `desktop-file-validate`, but the tool is not installed in the environment so validation was skipped.
- Attempted AppStream validation with `appstreamcli validate --no-net`, but `appstreamcli` is not installed in the environment so validation was skipped.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a22d92bb8f0832a9caa05b87f6e3054)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Reorganized Linux icon assets with multiple format variants for improved desktop environment integration.
  * Updated build configurations and validation processes to support expanded icon packaging.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->