### PR TITLE
Fix WebRTC for Linux and Windows Desktop Builds

### DIFF
--- a/desktop/main.cjs
+++ b/desktop/main.cjs
@@ -1,4 +1,4 @@
-const { app, BrowserWindow, shell } = require('electron');
+const { app, BrowserWindow, shell, session } = require('electron');
 const path = require('path');
 const { pathToFileURL } = require('url');
 
@@ -15,6 +15,19 @@ async function startBundledServer() {
 
 async function createWindow() {
   await startBundledServer();
+
+  // WebRTC and other permissions handling
+  session.defaultSession.setPermissionRequestHandler((webContents, permission, callback) => {
+    const url = webContents.getURL();
+    // Only allow permissions for our local server
+    if (url.startsWith(`http://127.0.0.1:${PORT}`) || url.startsWith(`http://localhost:${PORT}`)) {
+      const allowedPermissions = ['media', 'display-capture', 'mediaKeySystem'];
+      if (allowedPermissions.includes(permission)) {
+        return callback(true);
+      }
+    }
+    callback(false);
+  });
 
   mainWindow = new BrowserWindow({
     width: 1200,

--- a/public/scripts/network.js
+++ b/public/scripts/network.js
@@ -1150,11 +1150,27 @@ class RTCPeer extends Peer {
     }
 
     _openConnection() {
+        console.log('RTC: opening connection with config:', this.rtcConfig);
         this._conn = new RTCPeerConnection(this.rtcConfig);
         this._conn.onicecandidate = e => this._onIceCandidate(e);
-        this._conn.onicecandidateerror = e => this._onError(e);
-        this._conn.onconnectionstatechange = _ => this._onConnectionStateChange();
-        this._conn.oniceconnectionstatechange = e => this._onIceConnectionStateChange(e);
+        this._conn.onicecandidateerror = e => {
+            console.error('RTC: ICE candidate error:', e.errorCode, e.errorText, e.url);
+            this._onError(e);
+        };
+        this._conn.onconnectionstatechange = _ => {
+            console.log('RTC: connection state changed:', this._conn.connectionState);
+            this._onConnectionStateChange();
+        };
+        this._conn.oniceconnectionstatechange = e => {
+            console.log('RTC: ICE connection state changed:', this._conn.iceConnectionState);
+            this._onIceConnectionStateChange(e);
+        };
+        this._conn.onicegatheringstatechange = _ => {
+            console.log('RTC: ICE gathering state changed:', this._conn.iceGatheringState);
+        };
+        this._conn.onsignalingstatechange = _ => {
+            console.log('RTC: signaling state changed:', this._conn.signalingState);
+        };
     }
 
     _openChannel() {
@@ -1209,11 +1225,17 @@ class RTCPeer extends Peer {
     }
 
     _onChannelOpened(event) {
-        console.log('RTC: channel opened with', this._peerId);
         const channel = event.channel || event.target;
+        console.log('RTC: channel opened with', this._peerId, 'label:', channel.label);
         channel.binaryType = 'arraybuffer';
         channel.onmessage = e => this._onMessage(e.data);
-        channel.onclose = _ => this._onChannelClosed();
+        channel.onclose = _ => {
+            console.log('RTC: data channel closed with', this._peerId);
+            this._onChannelClosed();
+        };
+        channel.onerror = e => {
+            console.error('RTC: data channel error with', this._peerId, e);
+        };
         this._channel = channel;
         Events.on('beforeunload', e => this._onBeforeUnload(e));
         Events.on('pagehide', _ => this._onPageHide());

--- a/public/scripts/util.js
+++ b/public/scripts/util.js
@@ -39,6 +39,12 @@ if (!navigator.clipboard) {
 
 // Polyfills
 window.isRtcSupported = !!(window.RTCPeerConnection || window.mozRTCPeerConnection || window.webkitRTCPeerConnection);
+console.log('WebRTC support detected:', window.isRtcSupported);
+if (window.RTCPeerConnection) {
+    console.log('RTCPeerConnection is available.');
+} else {
+    console.warn('RTCPeerConnection is NOT available.');
+}
 
 window.hiddenProperty = 'hidden' in document
     ? 'hidden'

--- a/server/index.js
+++ b/server/index.js
@@ -46,7 +46,13 @@ conf.rtcConfig = process.env.RTC_CONFIG && process.env.RTC_CONFIG !== "false"
         "sdpSemantics": "unified-plan",
         "iceServers": [
             {
-                "urls": "stun:stun.l.google.com:19302"
+                "urls": [
+                    "stun:stun.l.google.com:19302",
+                    "stun:stun1.l.google.com:19302",
+                    "stun:stun2.l.google.com:19302",
+                    "stun:stun3.l.google.com:19302",
+                    "stun:stun4.l.google.com:19302"
+                ]
             }
         ]
     };


### PR DESCRIPTION
This PR addresses WebRTC connectivity issues in the ErikrafT Drop desktop builds for Linux and Windows.

Key changes:
1.  **Electron Permissions**: Added a `setPermissionRequestHandler` in `desktop/main.cjs` to explicitly grant WebRTC-related permissions for the local server origin.
2.  **Robust NAT Traversal**: Updated `server/index.js` to include five Google STUN servers in the default configuration, increasing the success rate of direct P2P connections.
3.  **Enhanced Diagnostics**: Implemented detailed logging in `public/scripts/network.js` and `public/scripts/util.js` to track ICE gathering, signaling, and data channel states.

These changes ensure that desktop builds prefer direct WebRTC connections and provide clear diagnostic information when issues occur, while maintaining server relay as a reliable fallback.

---
*PR created automatically by Jules for task [1358012990740803921](https://jules.google.com/task/1358012990740803921) started by @erikraft*

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Restricted media and display capture permissions to only the local app context, enhancing security by denying external permission requests.
  * Improved WebRTC server configuration with multiple STUN servers for better connection stability.

* **Chores**
  * Enhanced logging and diagnostics for WebRTC connection establishment and data channel operations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->