### PR TITLE
Update Linux Debian Packaging Metadata

### DIFF
--- a/.github/workflows/autofix.yml
+++ b/.github/workflows/autofix.yml
@@ -35,7 +35,7 @@ jobs:
       - name: Configure Git
         run: |
           git config --global user.name "autofix-bot"
-          git config --global user.email "autofix@users.noreply.github.com"
+          git config --global user.email "contact+app@erikraft.com"
 
       - name: Check for changes
         id: changes

--- a/.github/workflows/crowdin-sync.yml.disabled
+++ b/.github/workflows/crowdin-sync.yml.disabled
@@ -22,7 +22,7 @@ jobs:
       - name: Configure Git identity (BOT)
         run: |
           git config user.name "erikraft-drop-bot"
-          git config user.email "erikraft-drop-bot@users.noreply.github.com"
+          git config user.email "contact+app@erikraft.com"
 
       - name: Download translations from Crowdin
         uses: crowdin/github-action@v2

--- a/Discord/Bot/package.json
+++ b/Discord/Bot/package.json
@@ -3,6 +3,11 @@
   "version": "1.0.0",
   "type": "module",
   "description": "Bot do Discord para compartilhar arquivos através do ErikrafT Drop.",
+  "author": {
+    "name": "ErikrafT",
+    "email": "contact+app@erikraft.com",
+    "url": "https://github.com/erikraft"
+  },
   "overrides": {
     "undici": "^7.24.3"
   },

--- a/electron-builder.yml
+++ b/electron-builder.yml
@@ -28,6 +28,7 @@ linux:
       Categories: Network;Utility;
       Keywords: file;transfer;sharing
 deb:
+  maintainer: ErikrafT <contact+app@erikraft.com>
   fpm:
     - packaging/linux/icons/icon-drop.svg=/usr/share/icons/hicolor/scalable/apps/erikraft-drop.svg
     - packaging/linux/icons/android-chrome-512x512.png=/usr/share/icons/hicolor/512x512/apps/erikraft-drop.png

--- a/flatpak/io.github.erikraft.Drop.metainfo.xml
+++ b/flatpak/io.github.erikraft.Drop.metainfo.xml
@@ -3,6 +3,7 @@
   <id>io.github.erikraft.Drop</id>
   <metadata_license>CC0-1.0</metadata_license>
   <project_license>ISC</project_license>
+  <developer_name>ErikrafT</developer_name>
   <name>ErikrafT Drop</name>
   <summary>File sharing by ErikrafT Drop</summary>
   <description>

--- a/package.json
+++ b/package.json
@@ -15,7 +15,7 @@
   },
   "author": {
     "name": "ErikrafT",
-    "email": "erikraft@users.noreply.github.com",
+    "email": "contact+app@erikraft.com",
     "url": "https://github.com/erikraft"
   },
   "license": "ISC",


### PR DESCRIPTION
I have updated the packaging metadata for ErikrafT Drop to reflect the correct maintainer identity.

### Verification Report

| Modified File | Previous Value | New Value | Verification Method |
| :--- | :--- | :--- | :--- |
| `package.json` | `erikraft@users.noreply.github.com` | `contact+app@erikraft.com` | `read_file` |
| `electron-builder.yml` | (unset) | `maintainer: ErikrafT <contact+app@erikraft.com>` | `dpkg-deb -I` on built .deb |
| `.github/workflows/autofix.yml` | `autofix@users.noreply.github.com` | `contact+app@erikraft.com` | `read_file` |
| `.github/workflows/crowdin-sync.yml.disabled` | `erikraft-drop-bot@users.noreply.github.com` | `contact+app@erikraft.com` | `read_file` |
| `Discord/Bot/package.json` | (unset) | Added author field with new email | `read_file` |
| `flatpak/io.github.erikraft.Drop.metainfo.xml` | (unset) | `<developer_name>ErikrafT</developer_name>` | `read_file` |

### Final .deb Metadata Verification
I successfully built the Debian package and verified the `Maintainer` field:
```bash
$ dpkg-deb -I dist/desktop/erikraft-drop-1.12.4-linux-amd64.deb
 Package: erikraft-drop
 ...
 Vendor: ErikrafT <contact+app@erikraft.com>
 Maintainer: ErikrafT <contact+app@erikraft.com>
 ...
```
All repository-wide searches for `noreply.github.com` and old email addresses have been performed, and all packaging-related metadata is now up to date.

---
*PR created automatically by Jules for task [9376175337848659573](https://jules.google.com/task/9376175337848659573) started by @erikraft*

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated contact information across configuration files and metadata.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->