### PR TITLE
Standardize Debian package filename to erikraft-drop-linux-amd64.deb

### DIFF
--- a/.github/workflows/desktop-release.yml
+++ b/.github/workflows/desktop-release.yml
@@ -33,14 +33,14 @@ jobs:
         uses: actions/upload-artifact@v4
         with:
           name: erikraft-drop-linux-deb
-          path: dist/desktop/*.deb
+          path: dist/desktop/erikraft-drop-linux-amd64.deb
           if-no-files-found: error
 
       - name: Attach Linux package to release
         if: startsWith(github.ref, 'refs/tags/')
         uses: softprops/action-gh-release@v2
         with:
-          files: dist/desktop/*.deb
+          files: dist/desktop/erikraft-drop-linux-amd64.deb
 
   windows-exe:
     name: Build Windows .exe

--- a/electron-builder.yml
+++ b/electron-builder.yml
@@ -28,6 +28,7 @@ linux:
       Categories: Network;Utility;
       Keywords: file;transfer;sharing
 deb:
+  artifactName: erikraft-drop-linux-amd64.deb
   maintainer: ErikrafT <contact+app@erikraft.com>
   fpm:
     - packaging/linux/icons/icon-drop.svg=/usr/share/icons/hicolor/scalable/apps/erikraft-drop.svg


### PR DESCRIPTION
I have updated the ErikrafT Drop Linux packaging process to ensure that generated Debian packages always use a stable filename: `erikraft-drop-linux-amd64.deb`.

Key changes:
1.  **Modified `electron-builder.yml`**: Added `artifactName: erikraft-drop-linux-amd64.deb` to the `deb` section. This overrides the default versioned naming convention for the output file only.
2.  **Updated `.github/workflows/desktop-release.yml`**: Changed the artifact upload and GitHub Release attachment paths from `dist/desktop/*.deb` to the specific stable filename.
3.  **Verified Metadata**: Confirmed via `dpkg -I` that the internal package metadata still correctly identifies the version (e.g., `1.12.4`), fulfilling the requirement to keep internal versioning intact while standardizing the external filename.
4.  **Local Build Verification**: Successfully ran `npm run package:linux` and confirmed the produced file is exactly named `erikraft-drop-linux-amd64.deb`.

This ensures that the latest release is always accessible at the stable URL:
`https://github.com/erikraft/Drop/releases/latest/download/erikraft-drop-linux-amd64.deb`

---
*PR created automatically by Jules for task [5541261009164287884](https://jules.google.com/task/5541261009164287884) started by @erikraft*

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Standardized Linux Debian package naming in the release workflow and build configuration to ensure consistent artifact naming during the release process.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->