### PR TITLE
Resolve undici security vulnerabilities in Discord Bot

### DIFF
--- a/Discord/Bot/package-lock.json
+++ b/Discord/Bot/package-lock.json
@@ -289,9 +289,9 @@
       "license": "0BSD"
     },
     "node_modules/undici": {
-      "version": "7.24.3",
-      "resolved": "https://registry.npmjs.org/undici/-/undici-7.24.3.tgz",
-      "integrity": "sha512-eJdUmK/Wrx2d+mnWWmwwLRyA7OQCkLap60sk3dOK4ViZR7DKwwptwuIvFBg2HaiP9ESaEdhtpSymQPvytpmkCA==",
+      "version": "7.29.0",
+      "resolved": "https://registry.npmjs.org/undici/-/undici-7.29.0.tgz",
+      "integrity": "sha512-IDxfleLmmbSskfWSUATiN1nfn2rDuvnMOqb5CWR92iIfojA0Ud+ulOAAEQ57LPr9rWmsreUyf5lwyao+7GNNVw==",
       "license": "MIT",
       "engines": {
         "node": ">=20.18.1"


### PR DESCRIPTION
This submission resolves all GitHub Dependabot security alerts related to the "undici" package in the Discord Bot project. It regenerates the package-lock.json under Discord/Bot/ so that the transitive dependency resolves to the secure version 7.29.0, eliminating the vulnerabilities without requiring overrides or breaking changes.

---
*PR created automatically by Jules for task [16739415803024094656](https://jules.google.com/task/16739415803024094656) started by @erikraft*