### PR TITLE
Fix iSearch CLI icon

### DIFF
--- a/docs/ecosystem/isearch-cli.mdx
+++ b/docs/ecosystem/isearch-cli.mdx
@@ -1,7 +1,10 @@
 ---
 title: "iSearch CLI™"
 description: "Official ErikrafT Drop support for the iSearch CLI™ terminal client."
-icon: "cli"
+icon:
+  style: "solid"
+  name: "terminal"
+  library: "fontawesome"
 tag: "CLI"
 ---
 

--- a/docs/ecosystem/isearch-cli.mdx
+++ b/docs/ecosystem/isearch-cli.mdx
@@ -1,10 +1,7 @@
 ---
 title: "iSearch CLI™"
 description: "Official ErikrafT Drop support for the iSearch CLI™ terminal client."
-icon:
-  style: "solid"
-  name: "terminal"
-  library: "fontawesome"
+icon: "terminal"
 tag: "CLI"
 ---
 


### PR DESCRIPTION
Corrige o ícone da página iSearch CLI™ no grupo Ecosystem para usar o ícone Terminal do Font Awesome, mantendo o padrão visual das demais páginas.

<!-- mintlify-editor-comments:start -->
Mintlify
---
0 threads from 0 users in Mintlify

- No unresolved comments
<!-- mintlify-editor-comments:end -->

<!-- mintlify-comment-->

<a href="https://app.mintlify.com/erikraft/erikraft/editor/admin-mcp%2Fadd-isearch-cli-icon-bccd191?preview=%2Fecosystem%2Fisearch-cli&source=pr_comment" target="_blank" rel="noopener noreferrer"><picture><source media="(prefers-color-scheme: dark)" srcset="https://d3gk2c5xim1je2.cloudfront.net/assets/review-mintlify-editor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://d3gk2c5xim1je2.cloudfront.net/assets/review-mintlify-editor-light.svg"><img src="https://d3gk2c5xim1je2.cloudfront.net/assets/review-mintlify-editor-light.svg" alt="Review in Mintlify"></picture></a>

<!-- /mintlify-comment -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated the iSearch CLI documentation page to use a solid terminal icon in its navigation metadata.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->