### PR TITLE
fix: resolve initialization JSON error and cleanup experimental font

### DIFF
--- a/public/index.html
+++ b/public/index.html
@@ -9,6 +9,7 @@
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <meta name="theme-color" content="#3367d6">
     <meta name="color-scheme" content="dark light">
+    <meta name="mobile-web-app-capable" content="yes">
     <meta name="apple-mobile-web-app-capable" content="yes">
     <meta name="apple-mobile-web-app-status-bar-style" content="black-translucent">
     <meta name="apple-mobile-web-app-title" content="ErikrafT Drop™">
@@ -48,7 +49,6 @@
     <!-- Resources -->
     <link rel="preload" href="lang/en.json" as="fetch">
     <link rel="preload" href="fonts/OpenSans/static/OpenSans-Medium.ttf" as="font" type="font/ttf" crossorigin>
-    <link rel="preload" href="fonts/ErikrafT-Icon/ErikrafT-Icons.ttf" as="font" type="font/ttf" crossorigin>
     <link rel="stylesheet" type="text/css" href="styles/styles-main.css">
     <link rel="stylesheet" type="text/css" href="styles/content-moderation.css">
     <link rel="manifest" href="manifest.json">

--- a/public/lang/pt-BR.json
+++ b/public/lang/pt-BR.json
@@ -54,7 +54,7 @@
         "tor-status": "Rede Tor",
         "tor-status_title": "Conectado via Tor Onion Service",
         "use-tor": "Usar rede Tor",
-        "use-tor_title": "Configurar ou compartilhar transferência via rede Tor"
+        "use-tor_title": "Configurar ou compartilhar transferência via rede Tor",
         "traffic": "O tráfego é",
         "routed": "roteado pelo servidor",
         "webrtc": "se o WebRTC não estiver disponível.",

--- a/public/service-worker.js
+++ b/public/service-worker.js
@@ -1,4 +1,4 @@
-const cacheVersion = 'v1.12.4';
+const cacheVersion = 'v1.12.5';
 const cacheTitle = `erikraftdrop-cache-${cacheVersion}`;
 const relativePathsToCache = [
     './',

--- a/public/wolv.html.disabled
+++ b/public/wolv.html.disabled
@@ -41,7 +41,6 @@
     <!-- Resources -->
     <link rel="preload" href="lang/en.json" as="fetch">
     <link rel="preload" href="fonts/OpenSans/static/OpenSans-Medium.ttf" as="font" type="font/ttf" crossorigin>
-    <link rel="preload" href="fonts/ErikrafT-Icon/ErikrafT-Icons.ttf" as="font" type="font/ttf" crossorigin>
     <link rel="stylesheet" type="text/css" href="styles/styles-main.css">
     <link rel="stylesheet" type="text/css" href="styles/content-moderation.css">
     <link rel="manifest" href="manifest.json">


### PR DESCRIPTION
Fix critical initialization SyntaxError caused by missing comma in public/lang/pt-BR.json.
Remove experimental font ErikrafT-Icons.ttf preload link from index.html.
Add <meta name="mobile-web-app-capable" content="yes"> meta tag.
Increment Service Worker cache version to v1.12.5.

---
*PR created automatically by Jules for task [13189128226783144953](https://jules.google.com/task/13189128226783144953) started by @erikraft*