### PR TITLE
Fix Render Docker configuration for Onion Service

### DIFF
--- a/render.yaml
+++ b/render.yaml
@@ -2,7 +2,8 @@ services:
   - type: web
     name: erikraft-drop
     env: docker
-    dockerfilePath: onion-gateway/Dockerfile
+    dockerfilePath: ./Dockerfile
+    dockerContext: .
     plan: free
     region: oregon
     autoDeploy: true


### PR DESCRIPTION
Fixes render.yaml to set dockerfilePath to ./Dockerfile and dockerContext to . so that Render properly recognizes and builds the Docker runtime for the single Web Service.

---
*PR created automatically by Jules for task [16961824605660683109](https://jules.google.com/task/16961824605660683109) started by @erikraft*

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated the web service build configuration to use the repository’s root Dockerfile and build context.


<!-- end of auto-generated comment: release notes by coderabbit.ai -->