### PR TITLE
Fix discovery UI, Tor Browser WebRTC fallback, and Onion Service announcement

### DIFF
--- a/public/index.html
+++ b/public/index.html
@@ -857,7 +857,7 @@
                     <span class="badge badge-tor-network pointer" data-badge="tor" data-i18n-key="footer.tor-network"
                         data-i18n-attrs="text title" hidden>na rede Tor</span>
                     <span class="badge badge-tor-status" data-badge="tor-status" data-i18n-key="footer.tor-status"
-                        data-i18n-attrs="text title" style="background: rgba(125, 70, 150, 0.2); border: 1px solid rgba(125, 70, 150, 0.5);" hidden>Rede Tor</span>
+                        data-i18n-attrs="text title" hidden>Rede Tor</span>
                 </div>
             </div>
         </div>

--- a/public/scripts/ui-main.js
+++ b/public/scripts/ui-main.js
@@ -13,7 +13,7 @@ class DiscoveryBadgeState {
 
         this.state = {
             lan: false,
-            ip: false,
+            ip: true,
             paired: false,
             publicRoom: false,
             publicRoomId: null,
@@ -322,7 +322,7 @@ class DiscoveryBadgeState {
         const token = this.recoveryToken;
         this.patchState({
             lan: false,
-            ip: false,
+            ip: true,
             publicRoom: false,
             publicRoomId: null
         }, {

--- a/public/scripts/ui.js
+++ b/public/scripts/ui.js
@@ -82,7 +82,7 @@ class PeersUI {
         }
         else {
             this.$wsFallbackWarning.hidden = true;
-            if (!window.isRtcSupported) {
+            if (!window.isRtcSupported && !wsConfig.wsFallback) {
                 alert(Localization.getTranslation("instructions.webrtc-requirement"));
             }
         }

--- a/public/styles/styles-main.css
+++ b/public/styles/styles-main.css
@@ -576,6 +576,14 @@ footer .logo {
     --badge-color: var(--public-room-color);
 }
 
+.badge-tor-network {
+    --badge-color: var(--primary-color);
+}
+
+.badge-tor-status {
+    --badge-color: var(--tor-color, #7D4696);
+}
+
 .known-as-wrapper {
     font-size: 16px;
     /* prevents auto-zoom on edit */

--- a/server/index.js
+++ b/server/index.js
@@ -38,7 +38,7 @@ conf.debugMode = process.env.DEBUG_MODE === "true";
 
 conf.port = process.env.PORT || 3000;
 
-conf.wsFallback = process.argv.includes('--include-ws-fallback') || process.env.WS_FALLBACK === "true";
+conf.wsFallback = process.argv.includes('--include-ws-fallback') || process.env.WS_FALLBACK !== "false";
 
 conf.rtcConfig = process.env.RTC_CONFIG && process.env.RTC_CONFIG !== "false"
     ? JSON.parse(fs.readFileSync(process.env.RTC_CONFIG, 'utf8'))

--- a/server/server.js
+++ b/server/server.js
@@ -58,6 +58,35 @@ export default class ErikrafTdropServer {
         const __filename = fileURLToPath(import.meta.url);
         const __dirname = dirname(__filename);
 
+        // Middleware to announce Onion-Location header for Tor Service Discovery
+        let cachedOnionHost = null;
+        const getOnionHost = () => {
+            if (cachedOnionHost) return cachedOnionHost;
+            const torHostnamePath = '/var/lib/tor/erikraft_drop_onion/hostname';
+            try {
+                if (fs.existsSync(torHostnamePath)) {
+                    const host = fs.readFileSync(torHostnamePath, 'utf8').trim();
+                    if (host) {
+                        cachedOnionHost = host;
+                        return cachedOnionHost;
+                    }
+                }
+            } catch (err) {
+                // ignore error
+            }
+            return 'nozudb2e4jy4betognmnwoxvdu44wvjoqvmwios5ql7mxagqqpnn64ad.onion';
+        };
+
+        app.use((req, res, next) => {
+            const hostHeader = req.headers.host || req.hostname || '';
+            if (!hostHeader.endsWith('.onion')) {
+                const onionHost = getOnionHost();
+                const onionUrl = `http://${onionHost}${req.originalUrl || req.url || '/'}`;
+                res.setHeader('Onion-Location', onionUrl);
+            }
+            next();
+        });
+
         const publicPathAbs = path.join(__dirname, '../public');
         app.use(express.static(publicPathAbs));
 


### PR DESCRIPTION
Technical fixes for ErikrafT Drop™:
1. 'on this network' is retained as the default initial discovery mode across both normal domain and .onion connections.
2. Discovery UI badge styling updated: removed custom fading on 'on Tor network' badge and made 'Tor Network' badge solid purple (#7D4696).
3. Suppressed 'WebRTC must be enabled!' alert popup when WebSocket fallback is available, allowing Tor Browser users to seamlessly connect and transfer files over WebSockets.
4. Set default WebSocket fallback enabled (`WS_FALLBACK !== "false"`).
5. Implemented standard HTTP `Onion-Location` header in Express server responses to natively advertise the .onion address to Tor Browser.

---
*PR created automatically by Jules for task [4869590991570959589](https://jules.google.com/task/4869590991570959589) started by @erikraft*

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added clearer visual indicators for Tor network and connection status.
  - Added automatic Onion-Location discovery for compatible Tor deployments.
  - WebSocket fallback is now enabled by default.

- **Bug Fixes**
  - Improved discovery status initialization.
  - Prevented unnecessary WebRTC warnings when WebSocket fallback is available.
  - Removed inline styling from the Tor status badge for consistent appearance.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->