### PR TITLE
Fix visual contrast, styling and i18n in Tor Network Dialog

### DIFF
--- a/public/index.html
+++ b/public/index.html
@@ -1055,14 +1055,10 @@
         <x-background class="full center">
             <x-paper shadow="2">
                 <div class="row center p-2 dialog-header">
-                    <h2 class="dialog-title">
-                        <span data-i18n-key="dialogs.tor-title">Rede Tor (Onion Service)</span>
-                    </h2>
+                    <h2 class="dialog-title" data-i18n-key="dialogs.tor-title" data-i18n-attrs="text"></h2>
                 </div>
                 <div class="tor-dialog-body column center p-3">
-                    <p class="tor-description font-body2 text-center" data-i18n-key="dialogs.tor-desc">
-                        Transfira arquivos através da rede Tor usando o endereço Onion Service do ErikrafT Drop.
-                    </p>
+                    <p class="tor-description font-body2 text-center" data-i18n-key="dialogs.tor-desc" data-i18n-attrs="text"></p>
 
                     <div id="tor-address-wrapper" class="tor-address-card column center full-width">
                         <div id="tor-status-box" class="column center full-width"></div>
@@ -1071,21 +1067,19 @@
                     <div class="tor-actions column center full-width">
                         <a id="tor-open-btn" href="#" target="_blank" rel="noopener noreferrer" class="btn btn-rounded btn-tor full-width text-white" style="text-decoration: none;" hidden>
                             <svg class="icon btn-icon"><use xlink:href="#tor-icon"></use></svg>
-                            <span data-i18n-key="dialogs.tor-open-browser">Abrir endereço Onion</span>
+                            <span data-i18n-key="dialogs.tor-open-browser" data-i18n-attrs="text"></span>
                         </a>
                         <button id="tor-copy-btn" type="button" class="btn btn-rounded btn-grey full-width">
-							<span id="tor-copy-text" data-i18n-key="dialogs.tor-copy-address">Copiar endereço</span>
+							<span id="tor-copy-text" data-i18n-key="dialogs.tor-copy-address" data-i18n-attrs="text"></span>
                         </button>
                     </div>
 
                     <hr class="tor-divider">
 
-                    <p class="tor-help-text font-caption text-center" data-i18n-key="dialogs.tor-help">
-                        Abra este endereço .onion em um navegador compatível com a rede Tor.
-                    </p>
+                    <p class="tor-help-text font-caption text-center" data-i18n-key="dialogs.tor-help" data-i18n-attrs="text"></p>
                 </div>
                 <div class="center row-reverse btn-row wrap">
-                    <button class="btn btn-rounded btn-grey" type="button" data-i18n-key="dialogs.close" data-i18n-attrs="text" close>Fechar</button>
+                    <button class="btn btn-rounded btn-grey" type="button" data-i18n-key="dialogs.close" data-i18n-attrs="text" close></button>
                 </div>
             </x-paper>
         </x-background>

--- a/public/scripts/ui.js
+++ b/public/scripts/ui.js
@@ -2554,9 +2554,12 @@ class TorDialog extends Dialog {
                 <svg class="icon tor-spinner" style="width: 28px; height: 28px; margin-bottom: 10px;">
                     <use xlink:href="#tor-icon"></use>
                 </svg>
-                <span data-i18n-key="dialogs.tor-checking">Verificando conexão com a rede Tor...</span>
+                <span data-i18n-key="dialogs.tor-checking" data-i18n-attrs="text"></span>
             </div>
         `;
+        if (window.Localization && Localization.translateElement) {
+            $statusBox.querySelectorAll('[data-i18n-key]').forEach(el => Localization.translateElement(el));
+        }
         const $openBtn = this._getOpenBtn();
         const $copyBtn = this._getCopyBtn();
         if ($openBtn) $openBtn.hidden = true;
@@ -2570,13 +2573,16 @@ class TorDialog extends Dialog {
             <div class="tor-state-available column center text-center full-width">
                 <div class="tor-available-badge row center">
                     <span class="tor-dot pulse"></span>
-                    <span data-i18n-key="dialogs.tor-available">Rede Tor disponível</span>
+                    <span data-i18n-key="dialogs.tor-available" data-i18n-attrs="text"></span>
                 </div>
                 <div id="tor-onion-address-box" class="tor-onion-box" title="${onionAddress}">
                     ${onionAddress}
                 </div>
             </div>
         `;
+        if (window.Localization && Localization.translateElement) {
+            $statusBox.querySelectorAll('[data-i18n-key]').forEach(el => Localization.translateElement(el));
+        }
         const $openBtn = this._getOpenBtn();
         const $copyBtn = this._getCopyBtn();
         if ($openBtn) {
@@ -2598,16 +2604,17 @@ class TorDialog extends Dialog {
                     <svg class="icon" style="width: 22px; height: 22px; fill: currentColor;">
                         <use xlink:href="#tor-icon"></use>
                     </svg>
-                    <strong data-i18n-key="dialogs.tor-unavailable-title">ㅤEndereço Onion indisponível</strong>
+                    <strong data-i18n-key="dialogs.tor-unavailable-title" data-i18n-attrs="text"></strong>
                 </div>
-                <p class="font-caption text-secondary mt-1" style="opacity: 0.8; margin: 8px 0;" data-i18n-key="dialogs.tor-unavailable-desc">
-                    O serviço Tor ainda não está disponível. Tente novamente em alguns instantes.
-                </p>
+                <p class="font-caption text-secondary mt-1" style="opacity: 0.8; margin: 8px 0;" data-i18n-key="dialogs.tor-unavailable-desc" data-i18n-attrs="text"></p>
                 <button id="tor-refresh-btn" type="button" class="btn btn-small btn-rounded btn-outline-tor mt-1">
-                    <span data-i18n-key="dialogs.tor-refresh">Atualizar</span>
+                    <span data-i18n-key="dialogs.tor-refresh" data-i18n-attrs="text"></span>
                 </button>
             </div>
         `;
+        if (window.Localization && Localization.translateElement) {
+            $statusBox.querySelectorAll('[data-i18n-key]').forEach(el => Localization.translateElement(el));
+        }
 
         const $refreshBtn = $('tor-refresh-btn');
         if ($refreshBtn) {

--- a/public/styles/styles-deferred.css
+++ b/public/styles/styles-deferred.css
@@ -407,17 +407,29 @@ x-paper .dialog-title {
 
 .tor-address-card {
     width: 100%;
-    background: rgba(125, 70, 150, 0.08);
-    border: 1px solid rgba(125, 70, 150, 0.3);
+    background: #f8f3fa;
+    border: 1px solid rgba(125, 70, 150, 0.25);
     border-radius: 16px;
     padding: 16px;
     box-sizing: border-box;
     transition: all 0.2s ease-in-out;
 }
 
+body.dark-theme .tor-address-card {
+    background: rgba(125, 70, 150, 0.08);
+    border-color: rgba(125, 70, 150, 0.3);
+}
+
+@media (prefers-color-scheme: dark) {
+    body:not(.light-theme) .tor-address-card {
+        background: rgba(125, 70, 150, 0.08);
+        border-color: rgba(125, 70, 150, 0.3);
+    }
+}
+
 .tor-onion-box {
     width: 100%;
-    background: rgba(0, 0, 0, 0.25);
+    background: #f3e9f9;
     border-radius: 10px;
     padding: 12px 14px;
     box-sizing: border-box;
@@ -426,24 +438,42 @@ x-paper .dialog-title {
     font-family: SFMono-Regular, Consolas, "Liberation Mono", Menlo, monospace;
     font-size: 13px;
     line-height: 1.45;
-    color: #e2b3ff;
-    border: 1px solid rgba(125, 70, 150, 0.35);
+    color: #3c1352;
+    border: 1px solid rgba(125, 70, 150, 0.3);
     user-select: all;
     -webkit-user-select: all;
     text-align: center;
     margin-top: 10px;
 }
 
-body[theme="light"] .tor-onion-box {
-    background: #f3e9f9;
-    color: #5a1d7c;
-    border-color: rgba(125, 70, 150, 0.3);
+body.dark-theme .tor-onion-box {
+    background: rgba(0, 0, 0, 0.25);
+    color: #e2b3ff;
+    border-color: rgba(125, 70, 150, 0.35);
+}
+
+@media (prefers-color-scheme: dark) {
+    body:not(.light-theme) .tor-onion-box {
+        background: rgba(0, 0, 0, 0.25);
+        color: #e2b3ff;
+        border-color: rgba(125, 70, 150, 0.35);
+    }
 }
 
 .tor-available-badge {
-    color: #00e676;
+    color: #007a3d;
     font-weight: 600;
     font-size: 14px;
+}
+
+body.dark-theme .tor-available-badge {
+    color: #00e676;
+}
+
+@media (prefers-color-scheme: dark) {
+    body:not(.light-theme) .tor-available-badge {
+        color: #00e676;
+    }
 }
 
 .tor-dot {
@@ -451,9 +481,21 @@ body[theme="light"] .tor-onion-box {
     width: 10px;
     height: 10px;
     border-radius: 50%;
-    background-color: #00e676;
+    background-color: #007a3d;
     margin-right: 6px;
+    box-shadow: 0 0 8px rgba(0, 122, 61, 0.4);
+}
+
+body.dark-theme .tor-dot {
+    background-color: #00e676;
     box-shadow: 0 0 8px rgba(0, 230, 118, 0.6);
+}
+
+@media (prefers-color-scheme: dark) {
+    body:not(.light-theme) .tor-dot {
+        background-color: #00e676;
+        box-shadow: 0 0 8px rgba(0, 230, 118, 0.6);
+    }
 }
 
 .tor-dot.pulse {
@@ -494,10 +536,13 @@ body[theme="light"] .tor-onion-box {
 
 .tor-actions {
     width: 100%;
+    display: flex;
+    flex-direction: column;
     gap: 10px;
 }
 
 .tor-actions .btn {
+    width: 100%;
     min-height: 42px;
     font-size: 14px;
     display: flex;
@@ -508,6 +553,7 @@ body[theme="light"] .tor-onion-box {
     text-transform: none;
     letter-spacing: normal;
     font-weight: 600;
+    margin: 0;
 }
 
 .tor-actions .btn .btn-icon {


### PR DESCRIPTION
Fixed visual contrast and internationalization issues in the Tor Network Dialog:
- Improved .onion address contrast in Light Theme (#3c1352 text on #f3e9f9 background) while preserving high-contrast styling in Dark Theme.
- Standardized status indicator badge and dot colors for high contrast across both Light (#007a3d) and Dark (#00e676) themes.
- Aligned "Open Onion Address" and "Copy address" buttons consistently in a full-width flex container.
- Resolved language mixing by wiring all Tor Dialog strings to data-i18n-key attributes and Localization.translateElement.
- Ensured long .onion addresses wrap gracefully without clipping.
- Preserved all Tor functionality, WebSocket, pairing, and Onion Service endpoints.

---
*PR created automatically by Jules for task [583587202103354914](https://jules.google.com/task/583587202103354914) started by @erikraft*