### PR TITLE
Fix Temporary Public Room badge translation in i18n system

### DIFF
--- a/public/scripts/ui-main.js
+++ b/public/scripts/ui-main.js
@@ -507,7 +507,7 @@ class DiscoveryBadgeState {
             clearTimeout(this._hideTimers.get(timerKey));
             if (visible) {
                 el.hidden = false;
-                el.textContent = `na sala ${publicRoomId.toUpperCase()}`;
+                el.textContent = Localization.getTranslation("footer.public-room-devices", null, { roomId: publicRoomId.toUpperCase() });
                 this._hideTimers.delete(timerKey);
                 return;
             }


### PR DESCRIPTION
Fixed hardcoded Portuguese text ('na sala XXXXX') when rendering the temporary public room badge in public/scripts/ui-main.js. Replaced it with Localization.getTranslation("footer.public-room-devices", null, { roomId: publicRoomId.toUpperCase() }) to utilize the existing i18n system.

---
*PR created automatically by Jules for task [6857284512157046708](https://jules.google.com/task/6857284512157046708) started by @erikraft*

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Public-room badges now display localized text based on the room’s language settings instead of a fixed Portuguese label.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->