### PR TITLE
🐛 Fix animated QR receive UI and card spacing

### DIFF
--- a/public/index.html
+++ b/public/index.html
@@ -1565,18 +1565,18 @@
                 </div>
                 <div class="row center p-2">
                     <div class="column fw gap-3">
-                        <div class="erikraft-qr-card-send column center p-3 fw">
-                            <div class="font-body1 bold mb-2 text-primary" data-i18n-key="dialogs.animated-qr-send-section">Enviar</div>
-                            <div class="font-body2 text-center text-secondary mb-3" data-i18n-key="dialogs.animated-qr-send-description">Envie arquivos ou textos através de QR Codes animados.</div>
+                        <div class="erikraft-qr-card-send column center fw">
+                            <div class="font-body1 bold text-primary" data-i18n-key="dialogs.animated-qr-send-section">Enviar</div>
+                            <div class="font-body2 text-center text-secondary" data-i18n-key="dialogs.animated-qr-send-description">Envie arquivos ou textos através de QR Codes animados.</div>
                             <div class="row gap-2 fw center wrap">
                                 <button id="animated-qr-send-file-btn" type="button" class="btn btn-rounded btn-primary" data-i18n-key="dialogs.animated-qr-send-file">Enviar Arquivo</button>
                                 <button id="animated-qr-send-text-btn" type="button" class="btn btn-rounded btn-primary" data-i18n-key="dialogs.animated-qr-send-text">Enviar Texto</button>
                             </div>
                         </div>
 
-                        <div class="erikraft-qr-card-receive column center p-3 fw">
-                            <div class="font-body1 bold mb-2 text-paired" data-i18n-key="dialogs.animated-qr-receive-section">Receber</div>
-                            <div class="font-body2 text-center text-secondary mb-3" data-i18n-key="dialogs.animated-qr-receive-description">Aponte sua câmera para a tela do remetente.</div>
+                        <div class="erikraft-qr-card-receive column center fw">
+                            <div class="font-body1 bold text-paired" data-i18n-key="dialogs.animated-qr-receive-section">Receber</div>
+                            <div class="font-body2 text-center text-secondary" data-i18n-key="dialogs.animated-qr-receive-description">Aponte sua câmera para a tela do remetente.</div>
                             <button id="animated-qr-receive-btn" type="button" class="btn btn-rounded btn-primary btn-paired" data-i18n-key="dialogs.animated-qr-receive-action">Receber</button>
                         </div>
                     </div>

--- a/public/scripts/erikraft-qr.js
+++ b/public/scripts/erikraft-qr.js
@@ -417,15 +417,15 @@ class ErikrafTQRScanner {
 
                     try {
                         await this.videoEl.play();
-                        this.state = typeof Localization !== 'undefined' && typeof Localization.getTranslation === 'function'
+                        this.state = (typeof Localization !== 'undefined' && typeof Localization.getTranslation === 'function'
                             ? Localization.getTranslation('dialogs.camera-searching')
-                            : 'Procurando QR...';
+                            : 'Procurando QR...').replace(/[\.\s]*(?:Cole o link|Paste link).*/gi, '').trim();
                         this.onStateChange(this.state);
                     } catch (playErr) {
                         console.warn('Video play interrupted or rejected:', playErr);
-                        this.state = typeof Localization !== 'undefined' && typeof Localization.getTranslation === 'function'
+                        this.state = (typeof Localization !== 'undefined' && typeof Localization.getTranslation === 'function'
                             ? Localization.getTranslation('dialogs.camera-error-play')
-                            : 'Erro ao reproduzir vídeo';
+                            : 'Erro ao reproduzir vídeo').replace(/[\.\s]*(?:Cole o link|Paste link).*/gi, '').trim();
                         this.onStateChange(this.state);
                         this.onError(playErr);
                         this.stop();
@@ -436,12 +436,12 @@ class ErikrafTQRScanner {
                 console.warn('Camera access error:', err);
                 const isPermissionError = err && (err.name === 'NotAllowedError' || err.name === 'PermissionDeniedError');
                 this.state = isPermissionError
-                    ? (typeof Localization !== 'undefined' && typeof Localization.getTranslation === 'function'
+                    ? (typeof Localization !== 'undefined' && typeof Localization.getTranslation === 'function' && Localization.getTranslation('dialogs.camera-denied')
                         ? Localization.getTranslation('dialogs.camera-denied')
-                        : 'Acesso à câmera negado')
+                        : 'Acesso à câmera negado.').replace(/[\.\s]*(?:Cole o link|Paste link).*/gi, '').trim()
                     : (typeof Localization !== 'undefined' && typeof Localization.getTranslation === 'function'
                         ? Localization.getTranslation('dialogs.camera-unavailable')
-                        : 'Câmera indisponível ou não suportada');
+                        : 'Câmera indisponível.').replace(/[\.\s]*(?:Cole o link|Paste link).*/gi, '').trim();
                 this.onStateChange(this.state);
                 this.onError(err);
                 this.stop();
@@ -449,9 +449,9 @@ class ErikrafTQRScanner {
             }
         } else {
             const err = new Error('Camera unsupported');
-            this.state = typeof Localization !== 'undefined' && typeof Localization.getTranslation === 'function'
+            this.state = (typeof Localization !== 'undefined' && typeof Localization.getTranslation === 'function'
                 ? Localization.getTranslation('dialogs.camera-unsupported')
-                : 'Câmera não suportada';
+                : 'Câmera não suportada.').replace(/[\.\s]*(?:Cole o link|Paste link).*/gi, '').trim();
             this.onStateChange(this.state);
             this.onError(err);
             return;

--- a/public/scripts/ui.js
+++ b/public/scripts/ui.js
@@ -4077,9 +4077,10 @@ class AnimatedQRReceiveDialog extends Dialog {
             onError: (err) => {
                 if (this.$errorMsg) {
                     const isPermission = err && (err.name === 'NotAllowedError' || err.name === 'PermissionDeniedError');
-                    this.$errorMsg.textContent = isPermission
+                    const rawMsg = isPermission
                         ? (Localization.getTranslation('dialogs.camera-denied') || 'Acesso à câmera negado.')
                         : (Localization.getTranslation('dialogs.camera-unavailable') || 'Câmera indisponível.');
+                    this.$errorMsg.textContent = rawMsg.replace(/[\.\s]*(?:Cole o link|Paste link).*/gi, '').trim();
                 }
                 if (this.$errorContainer) {
                     this.$errorContainer.removeAttribute('hidden');

--- a/public/styles/styles-main.css
+++ b/public/styles/styles-main.css
@@ -1766,12 +1766,19 @@ See note here: https://developer.mozilla.org/en-US/docs/Web/CSS/user-select */
     max-height: 90vh;
     overflow-y: auto;
     box-sizing: border-box;
+    padding: 24px 20px !important;
+}
+
+.erikraft-qr-paper > .row.center.p-2 {
+    padding: 8px 0 !important;
 }
 
 .erikraft-qr-card-send {
     background: rgba(21, 172, 189, 0.08);
     border-radius: 12px;
     border: 1px solid rgba(21, 172, 189, 0.3);
+    padding: 20px 16px !important;
+    gap: 12px;
     transition: transform 0.2s ease, border-color 0.2s ease;
 }
 
@@ -1779,6 +1786,8 @@ See note here: https://developer.mozilla.org/en-US/docs/Web/CSS/user-select */
     background: rgba(0, 166, 156, 0.08);
     border-radius: 12px;
     border: 1px solid rgba(0, 166, 156, 0.3);
+    padding: 20px 16px !important;
+    gap: 12px;
     transition: transform 0.2s ease, border-color 0.2s ease;
 }
 


### PR DESCRIPTION
- Removed incorrect manual link paste instruction ("Cole o link manualmente abaixo:" / "Paste link manually below:") from camera status and error messages in the Animated QR Code receiving flow (`ErikrafTQRScanner` and `AnimatedQRReceiveDialog`).
- Fixed layout and spacing of `.erikraft-qr-paper` container and cards (`.erikraft-qr-card-send` and `.erikraft-qr-card-receive`) in `public/styles/styles-main.css` and `public/index.html` using clean flex gaps and container padding for responsive visual breathing room on desktop, tablet, and mobile.
- Preserved scanner functionality, frame processing, chunk reconstruction, CRC/SHA-256 verification, and all non-animated QR codes (e.g. pairing QR and temporary public room QR scanner).

---
*PR created automatically by Jules for task [7829000384132713092](https://jules.google.com/task/7829000384132713092) started by @erikraft*