### PR TITLE
Fix visual layout and spacing bug in Animated QR Code Dialog

### DIFF
--- a/public/index.html
+++ b/public/index.html
@@ -1581,7 +1581,7 @@
                         </div>
                     </div>
                 </div>
-                <div class="btn-row row-reverse wrap gap-2 p-2">
+                <div class="btn-row row-reverse wrap gap-2">
                     <button class="btn btn-rounded btn-grey" type="button" close data-i18n-key="dialogs.close">Fechar</button>
                 </div>
             </x-paper>
@@ -1592,12 +1592,12 @@
     <x-dialog id="animated-qr-send-dialog" class="erikraft-qr-dialog">
         <x-background class="full center">
             <x-paper shadow="2" class="erikraft-qr-paper">
-                <div class="row center p-2">
+                <div class="row center">
                     <h2 class="dialog-title" data-i18n-key="dialogs.animated-qr-send-title">Transferência por QR Code Animado</h2>
                 </div>
 
                 <!-- Composition View: Mode selection & input -->
-                <div id="qr-send-compose-view" class="row center p-2">
+                <div id="qr-send-compose-view" class="row center">
                     <div class="column fw gap-3">
                         <!-- Text composition container -->
                         <div id="qr-send-text-container" class="column fw">
@@ -1641,13 +1641,13 @@
                     </div>
                 </div>
 
-                <div id="qr-send-compose-buttons" class="btn-row row-reverse wrap gap-2 p-2">
+                <div id="qr-send-compose-buttons" class="btn-row row-reverse wrap gap-2">
                     <button id="qr-send-start-btn" type="button" class="btn btn-rounded btn-primary" data-i18n-key="dialogs.animated-qr-start-transfer">Iniciar Transferência</button>
                     <button type="button" class="btn btn-rounded btn-grey" close data-i18n-key="dialogs.cancel">Cancelar</button>
                 </div>
 
                 <!-- Active Streaming View -->
-                <div id="qr-send-active-view" class="row center p-2" hidden>
+                <div id="qr-send-active-view" class="row center" hidden>
                     <div class="column fw gap-2">
                         <div id="qr-send-file-info" class="font-body2 text-center bold" style="color: var(--primary-color, #15acbd);"></div>
 
@@ -1672,7 +1672,7 @@
                     </div>
                 </div>
 
-                <div id="qr-send-active-buttons" class="btn-row row-reverse wrap gap-2 p-2" hidden>
+                <div id="qr-send-active-buttons" class="btn-row row-reverse wrap gap-2" hidden>
                     <button id="qr-send-pause-btn" type="button" class="btn btn-rounded btn-grey" data-i18n-key="dialogs.animated-qr-pause">Pausar</button>
                     <button id="qr-send-back-btn" type="button" class="btn btn-rounded btn-grey" data-i18n-key="dialogs.animated-qr-back">Voltar</button>
                     <button type="button" class="btn btn-rounded btn-grey" close data-i18n-key="dialogs.close">Fechar</button>
@@ -1685,10 +1685,10 @@
     <x-dialog id="animated-qr-receive-dialog" class="erikraft-qr-dialog">
         <x-background class="full center">
             <x-paper shadow="2" class="erikraft-qr-paper">
-                <div class="row center p-2">
+                <div class="row center">
                     <h2 class="dialog-title" data-i18n-key="dialogs.animated-qr-receive-title">Receber por QR Code Animado</h2>
                 </div>
-                <div class="row center p-2">
+                <div class="row center">
                     <div class="column fw">
                         <div id="qr-receive-scanner-view" class="column center fw gap-2">
                             <!-- Professional camera container with proper sizing and overflow control -->
@@ -1731,7 +1731,7 @@
                         </div>
                     </div>
                 </div>
-                <div class="btn-row row-reverse wrap gap-2 p-2">
+                <div class="btn-row row-reverse wrap gap-2">
                     <button class="btn btn-rounded btn-grey" type="button" close data-i18n-key="dialogs.close">Fechar</button>
                 </div>
             </x-paper>

--- a/public/scripts/erikraft-qr.js
+++ b/public/scripts/erikraft-qr.js
@@ -419,13 +419,13 @@ class ErikrafTQRScanner {
                         await this.videoEl.play();
                         this.state = (typeof Localization !== 'undefined' && typeof Localization.getTranslation === 'function'
                             ? Localization.getTranslation('dialogs.camera-searching')
-                            : 'Procurando QR...').replace(/[\.\s]*(?:Cole o link|Paste link).*/gi, '').trim();
+                            : 'Procurando QR...').replace(/[\.\s]*(?:Cole o link|Paste link|Cole o).*$/gi, '').trim();
                         this.onStateChange(this.state);
                     } catch (playErr) {
                         console.warn('Video play interrupted or rejected:', playErr);
                         this.state = (typeof Localization !== 'undefined' && typeof Localization.getTranslation === 'function'
                             ? Localization.getTranslation('dialogs.camera-error-play')
-                            : 'Erro ao reproduzir vídeo').replace(/[\.\s]*(?:Cole o link|Paste link).*/gi, '').trim();
+                            : 'Erro ao reproduzir vídeo').replace(/[\.\s]*(?:Cole o link|Paste link|Cole o).*$/gi, '').trim();
                         this.onStateChange(this.state);
                         this.onError(playErr);
                         this.stop();
@@ -438,10 +438,10 @@ class ErikrafTQRScanner {
                 this.state = isPermissionError
                     ? (typeof Localization !== 'undefined' && typeof Localization.getTranslation === 'function' && Localization.getTranslation('dialogs.camera-denied')
                         ? Localization.getTranslation('dialogs.camera-denied')
-                        : 'Acesso à câmera negado.').replace(/[\.\s]*(?:Cole o link|Paste link).*/gi, '').trim()
+                        : 'Acesso à câmera negado.').replace(/[\.\s]*(?:Cole o link|Paste link|Cole o).*$/gi, '').trim()
                     : (typeof Localization !== 'undefined' && typeof Localization.getTranslation === 'function'
                         ? Localization.getTranslation('dialogs.camera-unavailable')
-                        : 'Câmera indisponível.').replace(/[\.\s]*(?:Cole o link|Paste link).*/gi, '').trim();
+                        : 'Câmera indisponível.').replace(/[\.\s]*(?:Cole o link|Paste link|Cole o).*$/gi, '').trim();
                 this.onStateChange(this.state);
                 this.onError(err);
                 this.stop();
@@ -451,7 +451,7 @@ class ErikrafTQRScanner {
             const err = new Error('Camera unsupported');
             this.state = (typeof Localization !== 'undefined' && typeof Localization.getTranslation === 'function'
                 ? Localization.getTranslation('dialogs.camera-unsupported')
-                : 'Câmera não suportada.').replace(/[\.\s]*(?:Cole o link|Paste link).*/gi, '').trim();
+                : 'Câmera não suportada.').replace(/[\.\s]*(?:Cole o link|Paste link|Cole o).*$/gi, '').trim();
             this.onStateChange(this.state);
             this.onError(err);
             return;

--- a/public/scripts/ui.js
+++ b/public/scripts/ui.js
@@ -4080,7 +4080,7 @@ class AnimatedQRReceiveDialog extends Dialog {
                     const rawMsg = isPermission
                         ? (Localization.getTranslation('dialogs.camera-denied') || 'Acesso à câmera negado.')
                         : (Localization.getTranslation('dialogs.camera-unavailable') || 'Câmera indisponível.');
-                    this.$errorMsg.textContent = rawMsg.replace(/[\.\s]*(?:Cole o link|Paste link).*/gi, '').trim();
+                    this.$errorMsg.textContent = rawMsg.replace(/[\.\s]*(?:Cole o link|Paste link|Cole o).*$/gi, '').trim();
                 }
                 if (this.$errorContainer) {
                     this.$errorContainer.removeAttribute('hidden');

--- a/public/styles/styles-deferred.css
+++ b/public/styles/styles-deferred.css
@@ -895,10 +895,10 @@ x-dialog .dialog-subheader {
 }
 
 #qr-send-canvas-container {
-    width: 300px;
-    height: 300px;
+    width: 260px;
+    height: 260px;
     max-width: 100%;
-    max-height: 300px;
+    max-height: 260px;
 }
 
 /* QR Receive Dialog */
@@ -919,10 +919,10 @@ x-dialog .dialog-subheader {
 /* Mobile Responsive Adjustments */
 @media (max-width: 768px) {
     #qr-send-canvas-container {
-        width: 250px;
-        height: 250px;
-        max-width: 90vw;
-        max-height: 90vw;
+        width: 220px;
+        height: 220px;
+        max-width: 85vw;
+        max-height: 85vw;
     }
 
     #qr-scanner-video,

--- a/public/styles/styles-main.css
+++ b/public/styles/styles-main.css
@@ -1761,16 +1761,16 @@ See note here: https://developer.mozilla.org/en-US/docs/Web/CSS/user-select */
 
 /* Dialog container limits */
 .erikraft-qr-paper {
-    max-width: 520px !important;
+    max-width: 480px !important;
     width: 92% !important;
     max-height: 90vh;
     overflow-y: auto;
     box-sizing: border-box;
-    padding: 24px 20px !important;
+    padding: 20px 16px !important;
 }
 
-.erikraft-qr-paper > .row.center.p-2 {
-    padding: 8px 0 !important;
+.erikraft-qr-paper > .row.center {
+    padding: 6px 0 !important;
 }
 
 .erikraft-qr-card-send {
@@ -2040,18 +2040,19 @@ See note here: https://developer.mozilla.org/en-US/docs/Web/CSS/user-select */
 /* Canvas Box */
 .erikraft-qr-canvas-box {
     background: #ffffff;
-    padding: 16px;
+    padding: 12px;
     border-radius: 16px;
-    width: 280px;
-    height: 280px;
+    width: 260px;
+    height: 260px;
     max-width: 100%;
-    max-height: 280px;
+    max-height: 260px;
     box-shadow: 0 4px 16px rgba(0, 0, 0, 0.2);
     display: flex;
     align-items: center;
     justify-content: center;
     overflow: hidden;
     margin: 0 auto;
+    box-sizing: border-box;
 }
 
 .erikraft-qr-canvas-box svg,


### PR DESCRIPTION
Fixes the visual layout and double-padding bug in Animated QR Code dialogs (`#animated-qr-send-dialog` and `#animated-qr-receive-dialog`).

Key improvements:
- Removed duplicate `p-2` utility padding classes from inner container rows and action button rows in `public/index.html`.
- Refined `.erikraft-qr-paper`, `#qr-send-canvas-container`, and `.erikraft-qr-canvas-box` max-widths, padding, and sizing in `styles-main.css` and `styles-deferred.css` for balanced desktop and mobile presentation.
- Removed legacy "Cole o link manualmente abaixo" / "Paste link manually below" text from camera status and error messages in the receive flow.
- Verified zero regressions across unit tests, cross-protocol interoperability tests, and Playwright visual screenshots/videos.

---
*PR created automatically by Jules for task [9294165257703577093](https://jules.google.com/task/9294165257703577093) started by @erikraft*

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved camera error and status message cleanup by removing trailing paste instructions in Portuguese and English.

* **Style**
  * Reduced QR code and dialog dimensions for a more compact display.
  * Optimized QR layouts and sizing on mobile screens.
  * Removed excess padding from QR dialog headers and action areas.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->