### PR TITLE
Fix Animated QR Dialog Layout and Spacing

### DIFF
--- a/public/index.html
+++ b/public/index.html
@@ -1560,7 +1560,7 @@
     <x-dialog id="animated-qr-main-dialog" class="erikraft-qr-dialog">
         <x-background class="full center">
             <x-paper shadow="2" class="erikraft-qr-paper">
-                <div class="row center p-2">
+                <div class="row center">
                     <h2 class="dialog-title" data-i18n-key="dialogs.animated-qr-title">Transferência por QR Code Animado</h2>
                 </div>
                 <div class="row center p-2">
@@ -1581,7 +1581,7 @@
                         </div>
                     </div>
                 </div>
-                <div class="btn-row row-reverse wrap gap-2">
+                <div class="btn-row row-reverse wrap">
                     <button class="btn btn-rounded btn-grey" type="button" close data-i18n-key="dialogs.close">Fechar</button>
                 </div>
             </x-paper>
@@ -1597,7 +1597,7 @@
                 </div>
 
                 <!-- Composition View: Mode selection & input -->
-                <div id="qr-send-compose-view" class="row center">
+                <div id="qr-send-compose-view" class="row center p-2">
                     <div class="column fw gap-3">
                         <!-- Text composition container -->
                         <div id="qr-send-text-container" class="column fw">
@@ -1641,13 +1641,13 @@
                     </div>
                 </div>
 
-                <div id="qr-send-compose-buttons" class="btn-row row-reverse wrap gap-2">
+                <div id="qr-send-compose-buttons" class="btn-row row-reverse wrap">
                     <button id="qr-send-start-btn" type="button" class="btn btn-rounded btn-primary" data-i18n-key="dialogs.animated-qr-start-transfer">Iniciar Transferência</button>
                     <button type="button" class="btn btn-rounded btn-grey" close data-i18n-key="dialogs.cancel">Cancelar</button>
                 </div>
 
                 <!-- Active Streaming View -->
-                <div id="qr-send-active-view" class="row center" hidden>
+                <div id="qr-send-active-view" class="row center p-2" hidden>
                     <div class="column fw gap-2">
                         <div id="qr-send-file-info" class="font-body2 text-center bold" style="color: var(--primary-color, #15acbd);"></div>
 
@@ -1672,7 +1672,7 @@
                     </div>
                 </div>
 
-                <div id="qr-send-active-buttons" class="btn-row row-reverse wrap gap-2" hidden>
+                <div id="qr-send-active-buttons" class="btn-row row-reverse wrap" hidden>
                     <button id="qr-send-pause-btn" type="button" class="btn btn-rounded btn-grey" data-i18n-key="dialogs.animated-qr-pause">Pausar</button>
                     <button id="qr-send-back-btn" type="button" class="btn btn-rounded btn-grey" data-i18n-key="dialogs.animated-qr-back">Voltar</button>
                     <button type="button" class="btn btn-rounded btn-grey" close data-i18n-key="dialogs.close">Fechar</button>
@@ -1688,7 +1688,7 @@
                 <div class="row center">
                     <h2 class="dialog-title" data-i18n-key="dialogs.animated-qr-receive-title">Receber por QR Code Animado</h2>
                 </div>
-                <div class="row center">
+                <div class="row center p-2">
                     <div class="column fw">
                         <div id="qr-receive-scanner-view" class="column center fw gap-2">
                             <!-- Professional camera container with proper sizing and overflow control -->
@@ -1731,7 +1731,7 @@
                         </div>
                     </div>
                 </div>
-                <div class="btn-row row-reverse wrap gap-2">
+                <div class="btn-row row-reverse wrap">
                     <button class="btn btn-rounded btn-grey" type="button" close data-i18n-key="dialogs.close">Fechar</button>
                 </div>
             </x-paper>

--- a/public/styles/styles-main.css
+++ b/public/styles/styles-main.css
@@ -1761,23 +1761,18 @@ See note here: https://developer.mozilla.org/en-US/docs/Web/CSS/user-select */
 
 /* Dialog container limits */
 .erikraft-qr-paper {
-    max-width: 480px !important;
-    width: 92% !important;
+    max-width: 480px;
+    width: 92%;
     max-height: 90vh;
     overflow-y: auto;
     box-sizing: border-box;
-    padding: 20px 16px !important;
-}
-
-.erikraft-qr-paper > .row.center {
-    padding: 6px 0 !important;
 }
 
 .erikraft-qr-card-send {
     background: rgba(21, 172, 189, 0.08);
     border-radius: 12px;
     border: 1px solid rgba(21, 172, 189, 0.3);
-    padding: 20px 16px !important;
+    padding: 16px;
     gap: 12px;
     transition: transform 0.2s ease, border-color 0.2s ease;
 }
@@ -1786,7 +1781,7 @@ See note here: https://developer.mozilla.org/en-US/docs/Web/CSS/user-select */
     background: rgba(0, 166, 156, 0.08);
     border-radius: 12px;
     border: 1px solid rgba(0, 166, 156, 0.3);
-    padding: 20px 16px !important;
+    padding: 16px;
     gap: 12px;
     transition: transform 0.2s ease, border-color 0.2s ease;
 }


### PR DESCRIPTION
Corrected the layout and spacing structure of the Animated QR Code dialogs in public/styles/styles-main.css and public/index.html. Removed global padding from `.erikraft-qr-paper` so the header sits flush against the top rounded corners without floating gaps, and ensured internal spacing is cleanly applied inside content view containers.

---
*PR created automatically by Jules for task [14624484493881222475](https://jules.google.com/task/14624484493881222475) started by @erikraft*