### PR TITLE
🎨 Fix: estender botão Fechar do QR Scanner

### DIFF
--- a/public/scripts/qr-helper.js
+++ b/public/scripts/qr-helper.js
@@ -224,15 +224,15 @@ window.ErikrafTDropQR = ErikrafTDropQR;
                 justify-content: center; align-items: center;
             }
             #qr-scanner-dialog .btn-row > button, #qr-scanner-confirm-dialog .btn-row > button {
-                margin-left: 0; margin-right: 0;
-            }
-            #qr-scanner-dialog .btn-row > #qr-scanner-close,
-            #qr-scanner-dialog .btn-row > #qr-scanner-manual-submit {
                 flex: 1 1 0;
                 min-width: 0;
+                margin-left: 0; margin-right: 0;
             }
-            #qr-scanner-dialog .btn-row > #qr-scanner-close {
-                width: 100%;
+            #qr-scanner-dialog #qr-scanner-close,
+            #qr-scanner-dialog #qr-scanner-manual-submit {
+                flex: 1 1 0;
+                width: auto;
+                min-width: 0;
             }
             #qr-scanner-confirm-dialog #qr-scanner-confirm-url {
                 display: block; width: 100%; margin: 0; padding: 14px 16px; box-sizing: border-box;
@@ -253,8 +253,8 @@ window.ErikrafTDropQR = ErikrafTDropQR;
                 #qr-scanner-dialog #qr-scanner-main-video { min-height: 180px; border-radius: 10px; }
                 #qr-scanner-confirm-dialog #qr-scanner-confirm-url { padding: 12px; }
                 #qr-scanner-dialog .btn-row > button, #qr-scanner-confirm-dialog .btn-row > button { flex: 1 1 140px; }
-                #qr-scanner-dialog .btn-row > #qr-scanner-close,
-                #qr-scanner-dialog .btn-row > #qr-scanner-manual-submit { flex: 1 1 140px; }
+                #qr-scanner-dialog #qr-scanner-close,
+                #qr-scanner-dialog #qr-scanner-manual-submit { flex: 1 1 140px; }
             }
         `;
         document.head.appendChild(style);

--- a/public/scripts/qr-helper.js
+++ b/public/scripts/qr-helper.js
@@ -226,6 +226,14 @@ window.ErikrafTDropQR = ErikrafTDropQR;
             #qr-scanner-dialog .btn-row > button, #qr-scanner-confirm-dialog .btn-row > button {
                 margin-left: 0; margin-right: 0;
             }
+            #qr-scanner-dialog .btn-row > #qr-scanner-close,
+            #qr-scanner-dialog .btn-row > #qr-scanner-manual-submit {
+                flex: 1 1 0;
+                min-width: 0;
+            }
+            #qr-scanner-dialog .btn-row > #qr-scanner-close {
+                width: 100%;
+            }
             #qr-scanner-confirm-dialog #qr-scanner-confirm-url {
                 display: block; width: 100%; margin: 0; padding: 14px 16px; box-sizing: border-box;
                 border-radius: 12px; line-height: 1.5; overflow-wrap: anywhere; word-break: break-word;
@@ -245,6 +253,8 @@ window.ErikrafTDropQR = ErikrafTDropQR;
                 #qr-scanner-dialog #qr-scanner-main-video { min-height: 180px; border-radius: 10px; }
                 #qr-scanner-confirm-dialog #qr-scanner-confirm-url { padding: 12px; }
                 #qr-scanner-dialog .btn-row > button, #qr-scanner-confirm-dialog .btn-row > button { flex: 1 1 140px; }
+                #qr-scanner-dialog .btn-row > #qr-scanner-close,
+                #qr-scanner-dialog .btn-row > #qr-scanner-manual-submit { flex: 1 1 140px; }
             }
         `;
         document.head.appendChild(style);


### PR DESCRIPTION
Corrige o visual do botão **Fechar** do QR Scanner para que ele tenha a mesma largura/alongamento do botão **Processar**.

### Alteração
- Faz o botão `Fechar` ocupar a largura disponível do rodapé, com dimensionamento consistente com `Processar`.
- Mantém alinhamento central e espaçamento correto.
- Mantém comportamento, i18n, temas e responsividade.
- Não altera a lógica de leitura ou classificação dos QR Codes.

A alteração é focada exclusivamente no layout dos botões do QR Scanner.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Style**
  - Improved QR scanner dialog layout so action buttons expand evenly and use available space more consistently on smaller screens.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->