### PR TITLE
✨ Improve Animated QR playback, seeking and initialization

### DIFF
--- a/public/scripts/qr-helper.js
+++ b/public/scripts/qr-helper.js
@@ -69,10 +69,13 @@ window.ErikrafTDropQR = ErikrafTDropQR;
 
 (function setupAnimatedQRPlaybackControls() {
     const BUTTON_IDS = {
+        initialize: 'qr-send-initialize-btn',
         previous: 'qr-send-previous-btn',
-        play: 'qr-send-play-btn',
         pause: 'qr-send-pause-btn',
-        next: 'qr-send-next-btn'
+        next: 'qr-send-next-btn',
+        seek: 'qr-send-frame-seek',
+        frameInput: 'qr-send-frame-input',
+        frameGo: 'qr-send-frame-go-btn'
     };
 
     const getTransmitter = () => {
@@ -80,9 +83,33 @@ window.ErikrafTDropQR = ErikrafTDropQR;
         return dialog && dialog.transmitter;
     };
 
-    const renderCurrentFrame = transmitter => {
+    const stopTimer = transmitter => {
+        if (!transmitter) return;
+        if (transmitter.timer) {
+            clearTimeout(transmitter.timer);
+            transmitter.timer = null;
+        }
+    };
+
+    const emitProgress = transmitter => {
+        if (!transmitter || !Array.isArray(transmitter.frames) || !transmitter.frames.length) return;
+        if (typeof transmitter.onProgress === 'function') {
+            transmitter.onProgress({
+                currentIndex: transmitter.currentIndex,
+                totalFrames: transmitter.frames.length,
+                numBaseChunks: transmitter.numBaseChunks,
+                fps: transmitter.fps,
+                totalSize: transmitter.totalSize,
+                fileName: transmitter.metadata ? transmitter.metadata.name : 'Data',
+                progressPct: Math.min(100, Math.round(((transmitter.currentIndex + 1) / transmitter.frames.length) * 100))
+            });
+        }
+    };
+
+    const renderCurrentFrame = (transmitter, force = false) => {
         if (!transmitter || !Array.isArray(transmitter.frames) || !transmitter.frames.length) return false;
-        const index = Math.max(0, Math.min(transmitter.currentIndex, transmitter.frames.length - 1));
+        if (!force && !transmitter.initialized) return false;
+        const index = Math.max(0, Math.min(Number.isFinite(transmitter.currentIndex) ? transmitter.currentIndex : 0, transmitter.frames.length - 1));
         transmitter.currentIndex = index;
         if (typeof ErikrafTDropQR !== 'undefined' && transmitter.containerEl) {
             ErikrafTDropQR.render(transmitter.containerEl, transmitter.frames[index], {
@@ -90,25 +117,39 @@ window.ErikrafTDropQR = ErikrafTDropQR;
                 height: 300
             });
         }
-        if (typeof transmitter.onProgress === 'function') {
-            transmitter.onProgress({
-                currentIndex: index,
-                totalFrames: transmitter.frames.length,
-                numBaseChunks: transmitter.numBaseChunks,
-                fps: transmitter.fps,
-                totalSize: transmitter.totalSize,
-                fileName: transmitter.metadata ? transmitter.metadata.name : 'Data',
-                progressPct: Math.min(100, Math.round(((index + 1) / transmitter.frames.length) * 100))
-            });
-        }
+        emitProgress(transmitter);
         return true;
     };
 
-    const stopTimer = transmitter => {
-        if (transmitter && transmitter.timer) {
-            clearTimeout(transmitter.timer);
-            transmitter.timer = null;
+    const syncSeekUI = transmitter => {
+        const seek = document.getElementById(BUTTON_IDS.seek);
+        const input = document.getElementById(BUTTON_IDS.frameInput);
+        if (!transmitter || !Array.isArray(transmitter.frames) || !transmitter.frames.length) return;
+        const total = transmitter.frames.length;
+        const current = Math.max(0, Math.min(transmitter.currentIndex, total - 1));
+        if (seek) {
+            seek.min = '0';
+            seek.max = String(total - 1);
+            seek.value = String(current);
+            seek.setAttribute('aria-valuetext', `QR ${current + 1} de ${total}`);
         }
+        if (input) {
+            input.min = '1';
+            input.max = String(total);
+            input.value = String(current + 1);
+            input.setAttribute('aria-label', `Número do QR, de 1 a ${total}`);
+        }
+    };
+
+    const setFrame = (transmitter, index) => {
+        if (!transmitter || !Array.isArray(transmitter.frames) || !transmitter.frames.length) return;
+        stopTimer(transmitter);
+        transmitter.running = true;
+        transmitter.paused = true;
+        transmitter.initialized = true;
+        transmitter.currentIndex = Math.max(0, Math.min(index, transmitter.frames.length - 1));
+        renderCurrentFrame(transmitter, true);
+        syncSeekUI(transmitter);
     };
 
     const installTransmitterControls = transmitter => {
@@ -116,39 +157,44 @@ window.ErikrafTDropQR = ErikrafTDropQR;
         if (!Array.isArray(transmitter.frames)) return;
 
         transmitter.__erikraftPlaybackControlsInstalled = true;
-
-        const originalStart = typeof transmitter.start === 'function' ? transmitter.start.bind(transmitter) : null;
-        const originalPause = typeof transmitter.pause === 'function' ? transmitter.pause.bind(transmitter) : null;
-        const originalResume = typeof transmitter.resume === 'function' ? transmitter.resume.bind(transmitter) : null;
+        transmitter.initialized = false;
 
         transmitter.start = function () {
             if (!this.frames || !this.frames.length) return;
             stopTimer(this);
             this.running = true;
             this.paused = true;
+            this.initialized = false;
             this.currentIndex = 0;
-            renderCurrentFrame(this);
+            syncSeekUI(this);
+        };
+
+        transmitter.initialize = function () {
+            if (!this.frames || !this.frames.length) return;
+            stopTimer(this);
+            this.running = true;
+            this.paused = true;
+            this.initialized = true;
+            this.currentIndex = Math.max(0, Math.min(this.currentIndex, this.frames.length - 1));
+            renderCurrentFrame(this, true);
+            syncSeekUI(this);
         };
 
         transmitter.pause = function () {
-            if (originalPause) originalPause();
-            else {
-                this.paused = true;
-                stopTimer(this);
-            }
-            this.paused = true;
             stopTimer(this);
-            renderCurrentFrame(this);
+            this.paused = true;
+            syncSeekUI(this);
         };
 
         transmitter.resume = function () {
-            if (!this.running || !this.frames || !this.frames.length) return;
+            if (!this.running || !this.initialized || !this.frames || !this.frames.length) return;
             stopTimer(this);
             this.paused = false;
             const tick = () => {
-                if (!this.running || this.paused || !this.frames.length) return;
-                renderCurrentFrame(this);
+                if (!this.running || this.paused || !this.initialized || !this.frames.length) return;
+                renderCurrentFrame(this, true);
                 this.currentIndex = (this.currentIndex + 1) % this.frames.length;
+                syncSeekUI(this);
                 this.timer = setTimeout(tick, 1000 / this.fps);
             };
             tick();
@@ -156,33 +202,32 @@ window.ErikrafTDropQR = ErikrafTDropQR;
 
         transmitter.previousFrame = function () {
             if (!this.frames || !this.frames.length) return;
-            stopTimer(this);
-            this.running = true;
-            this.paused = true;
-            this.currentIndex = Math.max(0, this.currentIndex - 1);
-            renderCurrentFrame(this);
+            setFrame(this, this.currentIndex - 1);
         };
 
         transmitter.nextFrame = function () {
             if (!this.frames || !this.frames.length) return;
-            stopTimer(this);
-            this.running = true;
-            this.paused = true;
-            this.currentIndex = Math.min(this.frames.length - 1, this.currentIndex + 1);
-            renderCurrentFrame(this);
+            setFrame(this, this.currentIndex + 1);
         };
 
-        if (originalStart && !this.__erikraftOriginalStart) {
-            this.__erikraftOriginalStart = originalStart;
-        }
-        if (originalPause && !this.__erikraftOriginalPause) {
-            this.__erikraftOriginalPause = originalPause;
-        }
-        if (originalResume && !this.__erikraftOriginalResume) {
-            this.__erikraftOriginalResume = originalResume;
-        }
+        transmitter.seekFrame = function (index) {
+            if (!this.frames || !this.frames.length) return;
+            setFrame(this, index);
+        };
 
-        renderCurrentFrame(transmitter);
+        syncSeekUI(transmitter);
+    };
+
+    const makeButton = (template, id, text, ariaLabel, onClick) => {
+        if (document.getElementById(id)) return;
+        const button = template.cloneNode(true);
+        button.id = id;
+        button.removeAttribute('data-i18n-key');
+        button.textContent = text;
+        button.setAttribute('aria-label', ariaLabel);
+        button.title = ariaLabel;
+        button.addEventListener('click', onClick);
+        return button;
     };
 
     const setup = () => {
@@ -193,47 +238,135 @@ window.ErikrafTDropQR = ErikrafTDropQR;
         const transmitter = getTransmitter();
         if (transmitter) installTransmitterControls(transmitter);
 
-        if (!document.getElementById(BUTTON_IDS.previous)) {
-            const previousButton = pauseButton.cloneNode(true);
-            previousButton.id = BUTTON_IDS.previous;
-            previousButton.removeAttribute('data-i18n-key');
-            previousButton.textContent = 'Anterior';
-            previousButton.setAttribute('aria-label', 'Mostrar QR anterior');
-            previousButton.title = 'Mostrar QR anterior';
-            previousButton.addEventListener('click', () => {
-                const current = getTransmitter();
-                if (current && typeof current.previousFrame === 'function') current.previousFrame();
-            });
-            activeButtons.insertBefore(previousButton, activeButtons.firstElementChild);
+        const current = getTransmitter();
+        if (!current) return;
+
+        if (!document.getElementById(BUTTON_IDS.initialize)) {
+            const initializeButton = makeButton(
+                pauseButton,
+                BUTTON_IDS.initialize,
+                'Inicializar',
+                'Inicializar QR animado',
+                () => {
+                    const tx = getTransmitter();
+                    if (tx && typeof tx.initialize === 'function') tx.initialize();
+                    const button = document.getElementById(BUTTON_IDS.initialize);
+                    if (button) button.hidden = true;
+                }
+            );
+            if (initializeButton) activeButtons.insertBefore(initializeButton, activeButtons.firstElementChild);
         }
 
-        if (!document.getElementById(BUTTON_IDS.play)) {
-            const playButton = pauseButton.cloneNode(true);
-            playButton.id = BUTTON_IDS.play;
-            playButton.removeAttribute('data-i18n-key');
-            playButton.textContent = 'Play';
-            playButton.setAttribute('aria-label', 'Iniciar transferência de QR animado');
-            playButton.title = 'Iniciar transferência de QR animado';
-            playButton.addEventListener('click', () => {
-                const current = getTransmitter();
-                if (current && current.running && typeof current.resume === 'function') current.resume();
-            });
-            activeButtons.insertBefore(playButton, pauseButton);
+        if (!document.getElementById(BUTTON_IDS.previous)) {
+            const previousButton = makeButton(
+                pauseButton,
+                BUTTON_IDS.previous,
+                'Anterior',
+                'Mostrar QR anterior',
+                () => {
+                    const tx = getTransmitter();
+                    if (tx && typeof tx.previousFrame === 'function') tx.previousFrame();
+                }
+            );
+            if (previousButton) activeButtons.insertBefore(previousButton, activeButtons.firstElementChild);
         }
 
         if (!document.getElementById(BUTTON_IDS.next)) {
-            const nextButton = pauseButton.cloneNode(true);
-            nextButton.id = BUTTON_IDS.next;
-            nextButton.removeAttribute('data-i18n-key');
-            nextButton.textContent = 'Próximo';
-            nextButton.setAttribute('aria-label', 'Mostrar próximo QR');
-            nextButton.title = 'Mostrar próximo QR';
-            nextButton.addEventListener('click', () => {
-                const current = getTransmitter();
-                if (current && typeof current.nextFrame === 'function') current.nextFrame();
-            });
-            activeButtons.insertBefore(nextButton, pauseButton);
+            const nextButton = makeButton(
+                pauseButton,
+                BUTTON_IDS.next,
+                'Próximo',
+                'Mostrar próximo QR',
+                () => {
+                    const tx = getTransmitter();
+                    if (tx && typeof tx.nextFrame === 'function') tx.nextFrame();
+                }
+            );
+            if (nextButton) activeButtons.insertBefore(nextButton, pauseButton.nextSibling);
         }
+
+        pauseButton.textContent = current.paused ? 'Play' : 'Pausar';
+        pauseButton.removeAttribute('data-i18n-key');
+        pauseButton.setAttribute('aria-label', current.paused ? 'Reproduzir QR animado' : 'Pausar QR animado');
+        pauseButton.title = current.paused ? 'Reproduzir QR animado' : 'Pausar QR animado';
+        pauseButton.onclick = () => {
+            const tx = getTransmitter();
+            if (!tx || !tx.initialized) return;
+            if (tx.paused) {
+                tx.resume();
+            } else {
+                tx.pause();
+            }
+            pauseButton.textContent = tx.paused ? 'Play' : 'Pausar';
+            pauseButton.setAttribute('aria-label', tx.paused ? 'Reproduzir QR animado' : 'Pausar QR animado');
+            pauseButton.title = tx.paused ? 'Reproduzir QR animado' : 'Pausar QR animado';
+        };
+
+        let seek = document.getElementById(BUTTON_IDS.seek);
+        if (!seek) {
+            seek = document.createElement('input');
+            seek.type = 'range';
+            seek.id = BUTTON_IDS.seek;
+            seek.className = 'fw';
+            seek.setAttribute('aria-label', 'Posição do QR animado');
+            seek.style.cssText = 'width:100%;accent-color:#0d6efd;cursor:pointer;';
+            const seekWrapper = document.createElement('div');
+            seekWrapper.id = 'qr-send-frame-seek-wrapper';
+            seekWrapper.className = 'fw column gap-1';
+            seekWrapper.style.margin = '8px 0 0';
+            seekWrapper.appendChild(seek);
+            activeButtons.parentNode.insertBefore(seekWrapper, activeButtons);
+            seek.addEventListener('input', event => {
+                const tx = getTransmitter();
+                if (!tx || !tx.frames || !tx.frames.length) return;
+                setFrame(tx, Number(event.target.value));
+            });
+        }
+
+        let frameInput = document.getElementById(BUTTON_IDS.frameInput);
+        if (!frameInput) {
+            frameInput = document.createElement('input');
+            frameInput.type = 'number';
+            frameInput.id = BUTTON_IDS.frameInput;
+            frameInput.className = 'btn btn-rounded btn-grey';
+            frameInput.min = '1';
+            frameInput.step = '1';
+            frameInput.inputMode = 'numeric';
+            frameInput.style.cssText = 'width:90px;text-align:center;';
+            frameInput.setAttribute('aria-label', 'Número do QR');
+            const frameGo = document.createElement('button');
+            frameGo.type = 'button';
+            frameGo.id = BUTTON_IDS.frameGo;
+            frameGo.className = 'btn btn-rounded btn-grey';
+            frameGo.textContent = 'Ir';
+            frameGo.setAttribute('aria-label', 'Ir para o QR informado');
+            frameGo.title = 'Ir para o QR informado';
+            const frameGroup = document.createElement('div');
+            frameGroup.id = 'qr-send-frame-input-group';
+            frameGroup.className = 'row center gap-2';
+            frameGroup.style.cssText = 'width:100%;justify-content:center;margin:8px 0 0;';
+            frameGroup.append(frameInput, frameGo);
+            activeButtons.parentNode.insertBefore(frameGroup, activeButtons);
+            const goToFrame = () => {
+                const tx = getTransmitter();
+                if (!tx || !tx.frames || !tx.frames.length) return;
+                const value = Number.parseInt(frameInput.value, 10);
+                if (!Number.isFinite(value)) return;
+                setFrame(tx, value - 1);
+            };
+            frameGo.addEventListener('click', goToFrame);
+            frameInput.addEventListener('keydown', event => {
+                if (event.key === 'Enter') {
+                    event.preventDefault();
+                    goToFrame();
+                }
+            });
+        }
+
+        syncSeekUI(current);
+
+        const initializeButton = document.getElementById(BUTTON_IDS.initialize);
+        if (initializeButton) initializeButton.hidden = !!current.initialized;
     };
 
     const runSetup = () => {


### PR DESCRIPTION
## Objetivo
Melhorar o controle do envio por QR Code Animado para que o remetente possa preparar o arquivo/texto, esperar o receptor e escolher exatamente qual QR/frame transmitir.

### Controles
- Remover o botão **Play** separado.
- Usar o próprio botão de reprodução como **Play/Pausar**: quando pausado, exibe `Play`; quando reproduzindo, exibe `Pausar`.
- Adicionar **Anterior** e **Próximo** para navegar um QR/frame por vez.
- Adicionar uma barra de posição no estilo de uma barra de vídeo, com destaque azul, que altera o QR imediatamente ao arrastar.
- Adicionar campo numérico para informar diretamente o número do QR/frame e botão **Ir**.

### Inicialização segura
- Depois de selecionar um arquivo ou preparar um texto e entrar na transferência, o QR **não começa a reproduzir sozinho**.
- O transmissor fica preparado, mas sem inicializar/exibir frames automaticamente.
- O botão **Inicializar** aparece para que o remetente possa esperar a outra pessoa chegar com o celular.
- Somente após **Inicializar** o primeiro QR é exibido.
- A partir daí, Play/Pausar e a navegação manual controlam os frames.

### Integridade
- A navegação usa os frames já gerados em memória.
- Não modifica payloads nem recria os dados da transferência.
- Não altera EKQR, CRC32, SHA-256, compressão ou FEC.
- Ao navegar manualmente, a reprodução é pausada para evitar corrida entre slider/botões e o timer.
- O timer anterior é sempre cancelado antes de uma nova reprodução.

### QR Scanner
- Mantém a restauração do layout anterior dos botões **Fechar** e **Processar** feita no PR anterior.

### Escopo
- Apenas `public/scripts/qr-helper.js`.
- Sem backend, banco de dados ou alteração do protocolo.
- **Não fazer merge automaticamente; PR aberto para revisão.**