### PR TITLE
🐛 Fix Animated QR mobile UI, text mode and playback controls

### DIFF
--- a/public/scripts/animated-qr-controls.js
+++ b/public/scripts/animated-qr-controls.js
@@ -23,38 +23,35 @@
         const input = document.getElementById(IDS.frameInput);
         if (input) { input.min='1'; input.max=String(total); input.value=String(tx.currentIndex+1); input.disabled=!tx.initialized; }
         const init = document.getElementById(IDS.initialize); if (init) init.hidden=!!tx.initialized;
-        const pause = document.getElementById(IDS.pause);
-        if (pause) { pause.textContent=tx.paused?'Play':'Pausar'; pause.removeAttribute('data-i18n-key'); pause.setAttribute('aria-label',tx.paused?'Reproduzir QR animado':'Pausar QR animado'); pause.title=tx.paused?'Play':'Pausar'; }
+        const pause = document.getElementById(IDS.pause); if (pause) { pause.textContent=tx.paused?'Play':'Pausar'; pause.removeAttribute('data-i18n-key'); pause.setAttribute('aria-label',tx.paused?'Reproduzir QR animado':'Pausar QR animado'); pause.title=tx.paused?'Play':'Pausar'; }
     };
     const select = (tx,index) => { if (!tx?.initialized || !tx.frames?.length) return; stopTimer(tx); tx.running=true; tx.paused=true; tx.currentIndex=clamp(tx,index); render(tx); sync(tx); };
     const install = tx => {
         if (!tx || tx.__erikraftRuntimeControlsInstalled) return;
         tx.__erikraftRuntimeControlsInstalled=true;
+        tx.__erikraftPlaybackControlsInstalled=true;
         tx.initialized=false;
         tx.start=function(){ if(!this.frames?.length)return; stopTimer(this); this.running=true; this.paused=true; this.initialized=false; this.currentIndex=0; if(this.containerEl&&window.ErikrafTDropQR?.destroy)window.ErikrafTDropQR.destroy(this.containerEl); sync(this); };
-        tx.initialize=function(){ if(!this.frames?.length)return; stopTimer(this); this.running=true; this.paused=true; this.initialized=true; this.currentIndex=clamp(this,this.currentIndex); render(this); sync(this); };
+        tx.initialize=function(){ if(!this.frames?.length)return; stopTimer(this); this.running=true; this.paused=true; this.initialized=true; this.currentIndex=clamp(this,this.currentIndex); const view=document.getElementById('qr-send-active-view'); if(view)view.hidden=false; render(this); sync(this); };
         tx.pause=function(){ stopTimer(this); this.paused=true; sync(this); };
         tx.resume=function(){ if(!this.running||!this.initialized||!this.frames?.length)return; stopTimer(this); this.paused=false; const tick=()=>{ if(!this.running||this.paused||!this.initialized||!this.frames?.length){stopTimer(this);sync(this);return;} render(this); this.currentIndex=(this.currentIndex+1)%this.frames.length; sync(this); this.timer=setTimeout(tick,1000/Math.max(1,Number(this.fps)||6)); }; tick(); };
-        tx.previousFrame=function(){select(this,this.currentIndex-1);};
-        tx.nextFrame=function(){select(this,this.currentIndex+1);};
-        tx.seekFrame=function(index){select(this,index);};
-        sync(tx);
+        tx.previousFrame=function(){select(this,this.currentIndex-1);}; tx.nextFrame=function(){select(this,this.currentIndex+1);}; tx.seekFrame=function(index){select(this,index);}; sync(tx);
     };
-    const makeButton=(id,text,label,handler,template)=>{ let b=document.getElementById(id); if(b)return b; b=template.cloneNode(true); b.id=id; b.type='button'; b.removeAttribute('data-i18n-key'); b.textContent=text; b.setAttribute('aria-label',label); b.title=label; b.onclick=handler; return b; };
+    const makeButton=(id,text,label,handler,template)=>{ let b=document.getElementById(id); if(b)return b; b=template.cloneNode(true); b.id=id; b.type='button'; b.removeAttribute('data-i18n-key'); b.textContent=text; b.setAttribute('aria-label',label); b.title=label; b.hidden=false; b.addEventListener('click',handler); return b; };
     const setup=tx=>{
         const buttons=document.getElementById(IDS.activeButtons), pause=document.getElementById(IDS.pause); if(!buttons||!pause||!tx)return false;
         install(tx);
         const init=makeButton(IDS.initialize,'Inicializar','Inicializar QR animado',()=>getTransmitter()?.initialize?.(),pause); if(!init.parentNode)buttons.insertBefore(init,buttons.firstElementChild);
         const prev=makeButton(IDS.previous,'Anterior','Mostrar QR anterior',()=>getTransmitter()?.previousFrame?.(),pause); if(!prev.parentNode)buttons.insertBefore(prev,buttons.firstElementChild);
         const next=makeButton(IDS.next,'Próximo','Mostrar próximo QR',()=>getTransmitter()?.nextFrame?.(),pause); if(!next.parentNode)buttons.insertBefore(next,pause.nextSibling);
-        pause.onclick=e=>{e.preventDefault();e.stopPropagation();const t=getTransmitter();if(!t?.initialized)return;t.paused?t.resume():t.pause();sync(t);};
+        if (!pause.dataset.erikraftControlCapture) { pause.dataset.erikraftControlCapture='true'; pause.addEventListener('click', event => { event.preventDefault(); event.stopImmediatePropagation(); const t=getTransmitter(); if(!t?.initialized)return; t.paused?t.resume():t.pause(); sync(t); }, true); }
         if(!document.getElementById(IDS.seek)){
             const w=document.createElement('div'); w.id=IDS.seekWrapper; w.className='fw column gap-1'; w.style.cssText='width:100%;margin:8px 0 0;';
-            const s=document.createElement('input'); s.type='range'; s.id=IDS.seek; s.className='fw'; s.style.cssText='width:100%;accent-color:#0d6efd;cursor:pointer;'; s.setAttribute('aria-label','Posição do QR animado'); s.addEventListener('input',e=>getTransmitter()?.seekFrame?.(Number(e.target.value))); w.appendChild(s); buttons.parentNode.insertBefore(w,buttons);
+            const s=document.createElement('input'); s.type='range'; s.id=IDS.seek; s.className='fw'; s.style.cssText='width:100%;accent-color:#0d6efd;cursor:pointer;touch-action:pan-x;'; s.setAttribute('aria-label','Posição do QR animado'); s.addEventListener('input',e=>getTransmitter()?.seekFrame?.(Number(e.target.value))); w.appendChild(s); buttons.parentNode.insertBefore(w,buttons);
         }
         if(!document.getElementById(IDS.frameInput)){
             const g=document.createElement('div'); g.id=IDS.frameGroup; g.className='row center gap-2'; g.style.cssText='width:100%;justify-content:center;margin:8px 0 0;flex-wrap:wrap;';
-            const i=document.createElement('input'); i.type='number'; i.id=IDS.frameInput; i.className='btn btn-rounded btn-grey'; i.min='1'; i.step='1'; i.inputMode='numeric'; i.style.cssText='width:90px;text-align:center;'; i.setAttribute('aria-label','Número do QR');
+            const i=document.createElement('input'); i.type='number'; i.id=IDS.frameInput; i.className='btn btn-rounded btn-grey'; i.min='1'; i.step='1'; i.inputMode='numeric'; i.style.cssText='width:min(90px,24vw);text-align:center;'; i.setAttribute('aria-label','Número do QR');
             const go=document.createElement('button'); go.type='button'; go.id=IDS.frameGo; go.className='btn btn-rounded btn-grey'; go.textContent='Ir'; go.setAttribute('aria-label','Ir para o QR informado'); go.title='Ir para o QR informado';
             const goFrame=()=>{const v=Number.parseInt(i.value,10);if(Number.isFinite(v))getTransmitter()?.seekFrame?.(v-1);}; go.onclick=goFrame; i.addEventListener('keydown',e=>{if(e.key==='Enter'){e.preventDefault();goFrame();}}); g.append(i,go); buttons.parentNode.insertBefore(g,buttons);
         }

--- a/public/styles/animated-qr-spacing.css
+++ b/public/styles/animated-qr-spacing.css
@@ -1,12 +1,5 @@
 /* ErikrafT Drop™ — Animated QR dialog visual spacing refinement */
-.erikraft-qr-dialog .erikraft-qr-paper {
-    overflow-x: hidden;
-    overflow-y: auto;
-    max-height: calc(100vh - 24px);
-    max-width: min(96vw, 720px);
-    min-height: 0;
-    box-sizing: border-box;
-}
+.erikraft-qr-dialog .erikraft-qr-paper { overflow-x: hidden; overflow-y: auto; max-height: calc(100vh - 24px); max-width: min(96vw, 720px); min-height: 0; box-sizing: border-box; }
 .erikraft-qr-dialog .erikraft-qr-paper > .row.center:has(.dialog-title) { flex: 0 0 auto; padding: 14px 18px; margin: 0; }
 .erikraft-qr-dialog .erikraft-qr-paper > .row.center:has(.dialog-title) .dialog-title { margin: 0; text-align: center; line-height: 1.35; }
 .erikraft-qr-dialog .erikraft-qr-paper > .row.center.p-3 { box-sizing: border-box; width: 100%; padding: 18px; min-width: 0; }
@@ -22,41 +15,24 @@
 #animated-qr-main-dialog .erikraft-qr-card-send .font-body2,
 #animated-qr-main-dialog .erikraft-qr-card-receive .font-body2 { max-width: 38em; margin: 0 0 4px; line-height: 1.55; }
 #animated-qr-main-dialog .erikraft-qr-card-send > .row { gap: 10px; }
-#animated-qr-send-dialog #qr-send-compose-view > .column { gap: 22px; }
+#animated-qr-send-dialog #qr-send-compose-view > .column { gap: 22px; min-width: 0; width: 100%; }
 #animated-qr-send-dialog #qr-send-text-container,
-#animated-qr-send-dialog #qr-send-file-container { gap: 10px; }
-#animated-qr-send-dialog #qr-send-text-input { margin: 0; }
-#animated-qr-send-dialog #qr-send-text-container > .row { margin-top: 2px; }
+#animated-qr-send-dialog #qr-send-file-container { gap: 10px; width: 100%; min-width: 0; box-sizing: border-box; }
+#animated-qr-send-dialog #qr-send-text-input { margin: 0; width: 100%; min-height: 120px; max-width: 100%; box-sizing: border-box; resize: vertical; }
+#animated-qr-send-dialog #qr-send-text-container > .row { margin-top: 2px; width: 100%; flex-wrap: wrap; }
 #animated-qr-send-dialog #qr-send-file-picker-wrapper { gap: 10px; }
 #animated-qr-send-dialog .erikraft-qr-dropzone-icon { margin-bottom: 0; }
-#animated-qr-send-dialog .erikraft-qr-selected-card { gap: 16px; }
-#animated-qr-send-dialog .erikraft-qr-card-actions { gap: 10px; }
-#animated-qr-send-dialog #qr-send-active-view > .column { gap: 16px; min-width: 0; }
-#animated-qr-send-dialog #qr-send-active-view { min-width: 0; }
-#animated-qr-send-dialog #qr-send-file-info { line-height: 1.5; padding: 0 4px; }
-#animated-qr-send-dialog #qr-send-canvas-container {
-    width: min(300px, 80vw);
-    height: min(300px, 80vw);
-    min-width: 220px;
-    min-height: 220px;
-    margin: 2px auto 4px;
-    display: flex;
-    align-items: center;
-    justify-content: center;
-    flex: 0 0 auto;
-    overflow: visible;
-}
+#animated-qr-send-dialog .erikraft-qr-selected-card { gap: 16px; min-width: 0; max-width: 100%; }
+#animated-qr-send-dialog .erikraft-qr-card-actions { gap: 10px; flex-wrap: wrap; }
+#animated-qr-send-dialog #qr-send-active-view > .column { gap: 16px; min-width: 0; width: 100%; }
+#animated-qr-send-dialog #qr-send-active-view { min-width: 0; width: 100%; box-sizing: border-box; }
+#animated-qr-send-dialog #qr-send-file-info { line-height: 1.5; padding: 0 4px; overflow-wrap: anywhere; }
+#animated-qr-send-dialog #qr-send-canvas-container { width: min(300px, 80vw); height: min(300px, 80vw); min-width: 220px; min-height: 220px; margin: 2px auto 4px; display: flex; align-items: center; justify-content: center; flex: 0 0 auto; overflow: hidden; box-sizing: border-box; }
 #animated-qr-send-dialog #qr-send-canvas-container > svg,
-#animated-qr-send-dialog #qr-send-canvas-container > canvas {
-    display: block;
-    width: 100%;
-    height: 100%;
-    max-width: 300px;
-    max-height: 300px;
-}
-#animated-qr-send-dialog #qr-send-active-view > .column > .fw.column { gap: 8px; }
+#animated-qr-send-dialog #qr-send-canvas-container > canvas { display: block; width: 100%; height: 100%; max-width: 300px; max-height: 300px; }
+#animated-qr-send-dialog #qr-send-active-view > .column > .fw.column { gap: 8px; min-width: 0; }
 #animated-qr-send-dialog #qr-send-active-view .font-body2.text-center { line-height: 1.55; padding: 0 8px; }
-#animated-qr-send-dialog #qr-send-fps-slider { min-width: 0; }
+#animated-qr-send-dialog #qr-send-fps-slider { min-width: 0; width: 100%; }
 #animated-qr-send-dialog #qr-send-frame-seek-wrapper { width: 100%; box-sizing: border-box; margin: 8px 0 0; }
 #animated-qr-send-dialog #qr-send-frame-seek { display: block; width: 100%; height: 8px; margin: 0; accent-color: #0d6efd; cursor: pointer; touch-action: pan-x; }
 #animated-qr-send-dialog #qr-send-frame-seek:focus-visible { outline: 2px solid #0d6efd; outline-offset: 3px; }
@@ -65,49 +41,42 @@
 #animated-qr-send-dialog #qr-send-frame-go-btn { min-height: 40px; }
 #animated-qr-send-dialog #qr-send-initialize-btn { min-width: 120px; }
 #animated-qr-send-dialog #qr-send-play-btn { display: none !important; }
-#animated-qr-send-dialog #qr-send-active-view:not([hidden]) ~ #qr-send-active-buttons[hidden] {
-    display: flex !important;
-}
-#animated-qr-send-dialog #qr-send-active-view:not([hidden]) ~ #qr-send-active-buttons {
-    flex-wrap: wrap;
-    justify-content: center;
-    align-items: center;
-}
-#animated-qr-send-dialog #qr-send-active-view:not([hidden]) ~ #qr-send-active-buttons > .btn {
-    flex: 1 1 140px;
-    min-width: 0;
-}
-#animated-qr-send-dialog #qr-send-active-view:not([hidden]) ~ #qr-send-active-buttons #qr-send-initialize-btn[hidden] {
-    display: none !important;
-}
-#animated-qr-send-dialog #qr-send-active-view:not([hidden]) ~ #qr-send-active-buttons .btn[close] {
-    flex: 1 1 140px;
-}
-#animated-qr-receive-dialog #qr-receive-scanner-view { gap: 14px; }
-#animated-qr-receive-dialog .erikraft-qr-camera-wrapper { margin-bottom: 2px; }
-#animated-qr-receive-dialog #qr-receive-state { line-height: 1.5; min-height: 18px; }
+#animated-qr-send-dialog #qr-send-active-view:not([hidden]) ~ #qr-send-active-buttons[hidden] { display: flex !important; }
+#animated-qr-send-dialog #qr-send-active-view:not([hidden]) ~ #qr-send-active-buttons { flex-wrap: wrap; justify-content: center; align-items: center; width: 100%; box-sizing: border-box; }
+#animated-qr-send-dialog #qr-send-active-view:not([hidden]) ~ #qr-send-active-buttons > .btn { flex: 1 1 140px; min-width: 0; }
+#animated-qr-send-dialog #qr-send-active-view:not([hidden]) ~ #qr-send-active-buttons #qr-send-initialize-btn[hidden] { display: none !important; }
+#animated-qr-send-dialog #qr-send-active-view:not([hidden]) ~ #qr-send-active-buttons .btn[close] { flex: 1 1 140px; }
+#animated-qr-receive-dialog #qr-receive-scanner-view { gap: 14px; min-width: 0; }
+#animated-qr-receive-dialog .erikraft-qr-camera-wrapper { margin-bottom: 2px; max-width: 100%; }
+#animated-qr-receive-dialog #qr-receive-state { line-height: 1.5; min-height: 18px; overflow-wrap: anywhere; }
 #animated-qr-receive-dialog #qr-receive-error-container { gap: 8px; box-sizing: border-box; width: 100%; }
-#animated-qr-receive-dialog #qr-receive-error-msg { margin-bottom: 0; line-height: 1.5; }
-#animated-qr-receive-dialog #qr-receive-scanner-view > .fw.column { gap: 8px; }
+#animated-qr-receive-dialog #qr-receive-error-msg { margin-bottom: 0; line-height: 1.5; overflow-wrap: anywhere; }
+#animated-qr-receive-dialog #qr-receive-scanner-view > .fw.column { gap: 8px; min-width: 0; }
 #animated-qr-receive-dialog #qr-receive-complete-container { gap: 8px; box-sizing: border-box; width: 100%; }
 #animated-qr-receive-dialog #qr-receive-complete-container > .mb-2,
 #animated-qr-receive-dialog #qr-receive-complete-container > .mb-1,
 #animated-qr-receive-dialog #qr-receive-complete-container > .mb-3 { margin-bottom: 0; }
-#animated-qr-receive-dialog #qr-receive-text-preview { margin: 4px 0 6px; }
+#animated-qr-receive-dialog #qr-receive-text-preview { margin: 4px 0 6px; overflow-wrap: anywhere; }
 .erikraft-qr-dialog .font-body1,
 .erikraft-qr-dialog .font-body2,
 .erikraft-qr-dialog .font-caption { overflow-wrap: anywhere; }
 @media (max-width: 480px) {
     .erikraft-qr-dialog .erikraft-qr-paper { max-height: calc(100vh - 12px); max-width: 98vw; }
     .erikraft-qr-dialog .erikraft-qr-paper > .row.center:has(.dialog-title) { padding: 12px 14px; }
-    .erikraft-qr-dialog .erikraft-qr-paper > .row.center.p-3 { padding: 14px; }
+    .erikraft-qr-dialog .erikraft-qr-paper > .row.center.p-3 { padding: 12px; }
     .erikraft-qr-dialog .erikraft-qr-paper > .erikraft-qr-btn-row,
-    .erikraft-qr-dialog .erikraft-qr-paper > .btn-row { padding: 8px 14px 14px; gap: 8px; }
-    #animated-qr-send-dialog #qr-send-compose-view > .column { gap: 18px; }
-    #animated-qr-main-dialog .erikraft-qr-card-send > .row { width: 100%; }
+    .erikraft-qr-dialog .erikraft-qr-paper > .btn-row { padding: 8px 12px 12px; gap: 8px; }
+    #animated-qr-send-dialog #qr-send-compose-view > .column { gap: 16px; }
+    #animated-qr-main-dialog .erikraft-qr-card-send > .row { width: 100%; flex-wrap: wrap; }
+    #animated-qr-send-dialog #qr-send-text-input { min-height: 110px; font-size: 16px; }
     #animated-qr-send-dialog #qr-send-fps-slider { width: 100%; }
     #animated-qr-send-dialog #qr-send-frame-input-group { flex-wrap: wrap; }
     #animated-qr-send-dialog #qr-send-frame-input { width: min(110px, 34vw); }
-    #animated-qr-send-dialog #qr-send-canvas-container { width: min(300px, 78vw); height: min(300px, 78vw); min-width: 200px; min-height: 200px; }
-    #animated-qr-send-dialog #qr-send-active-view:not([hidden]) ~ #qr-send-active-buttons > .btn { flex: 1 1 100%; }
+    #animated-qr-send-dialog #qr-send-canvas-container { width: min(300px, 78vw); height: min(300px, 78vw); min-width: 0; min-height: 0; max-width: 300px; max-height: 300px; }
+    #animated-qr-send-dialog #qr-send-active-view:not([hidden]) ~ #qr-send-active-buttons { padding-bottom: max(12px, env(safe-area-inset-bottom)); }
+    #animated-qr-send-dialog #qr-send-active-view:not([hidden]) ~ #qr-send-active-buttons > .btn { flex: 1 1 100%; min-height: 44px; }
+    #animated-qr-send-dialog #qr-send-text-container > .row > *, #animated-qr-send-dialog #qr-send-file-container > .row > * { min-width: 0; max-width: 100%; }
+}
+@media (min-width: 481px) {
+    #animated-qr-send-dialog #qr-send-active-buttons { max-height: 40vh; overflow-y: auto; }
 }


### PR DESCRIPTION
## Objetivo
Corrigir os problemas restantes do modo **Transferir via QR Code Animado** após o PR anterior, com foco no QR que não aparece, botões que somem/deixam de responder, botão Fechar, modo de envio de texto e layout em celulares como Xiaomi Redmi 9C.

## Correções
- Corrige o conflito entre os listeners antigo e novo do botão Play/Pausar; o controle passa a ter uma captura única e não pode ser revertido pelo listener legado.
- Mantém somente **Play / Pausar**; não recria botão Play duplicado e usa Play no estado pausado.
- Mantém **Inicializar** separado: preparar arquivo/texto não deve iniciar nem reproduzir o QR automaticamente.
- Inicializar renderiza explicitamente o primeiro frame e deixa a transferência pausada para o receptor começar a leitura.
- Play/Pausar, Anterior, Próximo, barra azul e campo numérico continuam sincronizados e limitados ao total de frames.
- Reforça o uso de `window.ErikrafTDropQR`, que é a API global exposta pelo helper, evitando falha de referência durante a renderização.
- Ajusta o container do QR para não ser cortado em telas pequenas e elimina largura mínima que podia estourar a viewport do Redmi 9C.
- Melhora o modo **Enviar Texto**, garantindo largura, altura, quebra de conteúdo e controles utilizáveis em mobile.
- Garante que os botões da etapa ativa possam quebrar linha e permanecer acessíveis, incluindo Fechar.
- Preserva rolagem vertical no PC e mobile e respeita safe-area inferior em celulares.
- Não altera o protocolo/FEC/CRC32/SHA-256/compressão/receptor.

## Verificação realizada
- Auditei a ordem de carregamento: `qr-helper.js` expõe `window.ErikrafTDropQR` antes de `animated-qr-controls.js` e o runtime é carregado depois do engine.
- Auditei `AnimatedQRSendDialog`: identifiquei que o botão de pausa tinha um listener legado via `addEventListener`, além do novo handler; isso podia fazer Play/Pausar se anularem.
- Auditei o fluxo de texto/arquivo e a troca compose -> active.
- Ajustei o CSS para viewport estreita e conteúdo flexível.

## Validação
A correção é feita para desktop, tablet e mobile, incluindo viewport estreita semelhante ao Xiaomi Redmi 9C. Não afirmo literalmente 'zero bugs' sem executar navegador real em cada dispositivo; o PR deve ser validado no preview antes do merge.

## Deploy
Este PR somente atualiza `master` após o merge pelo revisor. Depois do merge, as integrações de deploy do Render e do fallback Vercel devem receber o mesmo commit conforme a configuração desses serviços.