### PR TITLE
🐛 Fix: Animated QR root cause, rendering, controls and mobile layout

### DIFF
--- a/public/scripts/animated-qr-controls.js
+++ b/public/scripts/animated-qr-controls.js
@@ -1,17 +1,64 @@
 (function setupAnimatedQRRuntimeControls() {
     'use strict';
 
-    const IDS = { activeButtons:'qr-send-active-buttons', pause:'qr-send-pause-btn', initialize:'qr-send-initialize-btn', previous:'qr-send-previous-btn', next:'qr-send-next-btn', seek:'qr-send-frame-seek', frameInput:'qr-send-frame-input', frameGo:'qr-send-frame-go-btn', frameGroup:'qr-send-frame-input-group', seekWrapper:'qr-send-frame-seek-wrapper' };
+    const IDS = {
+        activeButtons: 'qr-send-active-buttons',
+        pause: 'qr-send-pause-btn',
+        initialize: 'qr-send-initialize-btn',
+        previous: 'qr-send-previous-btn',
+        next: 'qr-send-next-btn',
+        seek: 'qr-send-frame-seek',
+        frameInput: 'qr-send-frame-input',
+        frameGo: 'qr-send-frame-go-btn',
+        frameGroup: 'qr-send-frame-input-group',
+        seekWrapper: 'qr-send-frame-seek-wrapper'
+    };
+
     const getTransmitter = () => window.erikrafTdrop?.animatedQRSendDialog?.transmitter || null;
-    const stopTimer = tx => { if (tx?.timer) clearTimeout(tx.timer); if (tx) tx.timer = null; };
-    const clamp = (tx, index) => { const total = tx?.frames?.length || 0; if (!total) return 0; const n = Number(index); return Math.max(0, Math.min(Number.isFinite(n) ? Math.trunc(n) : 0, total - 1)); };
+    const stopTimer = tx => {
+        if (!tx) return;
+        if (tx.timer) clearTimeout(tx.timer);
+        tx.timer = null;
+    };
+    const clamp = (tx, index) => {
+        const total = Array.isArray(tx?.frames) ? tx.frames.length : 0;
+        if (!total) return 0;
+        const n = Number(index);
+        return Math.max(0, Math.min(Number.isFinite(n) ? Math.trunc(n) : 0, total - 1));
+    };
+    const showActive = () => {
+        const view = document.getElementById('qr-send-active-view');
+        const buttons = document.getElementById(IDS.activeButtons);
+        const canvas = document.getElementById('qr-send-canvas-container');
+        if (view) view.hidden = false;
+        if (buttons) buttons.hidden = false;
+        if (canvas) canvas.hidden = false;
+    };
     const render = tx => {
         if (!tx?.initialized || !tx.frames?.length || !tx.containerEl) return false;
         const qr = window.ErikrafTDropQR;
-        if (!qr || typeof qr.render !== 'function') return false;
+        if (!qr || typeof qr.render !== 'function') {
+            console.error('[Animated QR] ErikrafTDropQR renderer unavailable');
+            return false;
+        }
         tx.currentIndex = clamp(tx, tx.currentIndex);
-        qr.render(tx.containerEl, tx.frames[tx.currentIndex], { width:300, height:300, animatedTransfer:true });
-        if (typeof tx.onProgress === 'function') tx.onProgress({ currentIndex:tx.currentIndex, totalFrames:tx.frames.length, numBaseChunks:tx.numBaseChunks, fps:tx.fps, totalSize:tx.totalSize, fileName:tx.metadata?.name || 'Data', progressPct:Math.min(100, Math.round(((tx.currentIndex+1)/tx.frames.length)*100)) });
+        showActive();
+        qr.render(tx.containerEl, tx.frames[tx.currentIndex], {
+            width: 300,
+            height: 300,
+            animatedTransfer: true
+        });
+        if (typeof tx.onProgress === 'function') {
+            tx.onProgress({
+                currentIndex: tx.currentIndex,
+                totalFrames: tx.frames.length,
+                numBaseChunks: tx.numBaseChunks,
+                fps: tx.fps,
+                totalSize: tx.totalSize,
+                fileName: tx.metadata?.name || 'Data',
+                progressPct: Math.min(100, Math.round(((tx.currentIndex + 1) / tx.frames.length) * 100))
+            });
+        }
         return true;
     };
     const sync = tx => {
@@ -19,45 +66,196 @@
         tx.currentIndex = clamp(tx, tx.currentIndex);
         const total = tx.frames.length;
         const seek = document.getElementById(IDS.seek);
-        if (seek) { seek.min='0'; seek.max=String(total-1); seek.value=String(tx.currentIndex); seek.disabled=!tx.initialized; seek.setAttribute('aria-valuenow',String(tx.currentIndex)); seek.setAttribute('aria-valuetext',`QR ${tx.currentIndex+1} de ${total}`); }
+        if (seek) {
+            seek.min = '0';
+            seek.max = String(total - 1);
+            seek.value = String(tx.currentIndex);
+            seek.disabled = !tx.initialized;
+            seek.setAttribute('aria-valuemin', '0');
+            seek.setAttribute('aria-valuemax', String(total - 1));
+            seek.setAttribute('aria-valuenow', String(tx.currentIndex));
+            seek.setAttribute('aria-valuetext', `QR ${tx.currentIndex + 1} de ${total}`);
+        }
         const input = document.getElementById(IDS.frameInput);
-        if (input) { input.min='1'; input.max=String(total); input.value=String(tx.currentIndex+1); input.disabled=!tx.initialized; }
-        const init = document.getElementById(IDS.initialize); if (init) init.hidden=!!tx.initialized;
-        const pause = document.getElementById(IDS.pause); if (pause) { pause.textContent=tx.paused?'Play':'Pausar'; pause.removeAttribute('data-i18n-key'); pause.setAttribute('aria-label',tx.paused?'Reproduzir QR animado':'Pausar QR animado'); pause.title=tx.paused?'Play':'Pausar'; }
+        if (input) {
+            input.min = '1';
+            input.max = String(total);
+            input.value = String(tx.currentIndex + 1);
+            input.disabled = !tx.initialized;
+        }
+        const init = document.getElementById(IDS.initialize);
+        if (init) init.hidden = !!tx.initialized;
+        const pause = document.getElementById(IDS.pause);
+        if (pause) {
+            pause.textContent = tx.paused ? 'Play' : 'Pausar';
+            pause.removeAttribute('data-i18n-key');
+            pause.setAttribute('aria-label', tx.paused ? 'Reproduzir QR animado' : 'Pausar QR animado');
+            pause.title = tx.paused ? 'Play' : 'Pausar';
+            pause.disabled = !tx.initialized;
+        }
     };
-    const select = (tx,index) => { if (!tx?.initialized || !tx.frames?.length) return; stopTimer(tx); tx.running=true; tx.paused=true; tx.currentIndex=clamp(tx,index); render(tx); sync(tx); };
+    const select = (tx, index) => {
+        if (!tx?.initialized || !tx.frames?.length) return;
+        stopTimer(tx);
+        tx.running = true;
+        tx.paused = true;
+        tx.currentIndex = clamp(tx, index);
+        render(tx);
+        sync(tx);
+    };
     const install = tx => {
-        if (!tx || tx.__erikraftRuntimeControlsInstalled) return;
-        tx.__erikraftRuntimeControlsInstalled=true;
-        tx.__erikraftPlaybackControlsInstalled=true;
-        tx.initialized=false;
-        tx.start=function(){ if(!this.frames?.length)return; stopTimer(this); this.running=true; this.paused=true; this.initialized=false; this.currentIndex=0; if(this.containerEl&&window.ErikrafTDropQR?.destroy)window.ErikrafTDropQR.destroy(this.containerEl); sync(this); };
-        tx.initialize=function(){ if(!this.frames?.length)return; stopTimer(this); this.running=true; this.paused=true; this.initialized=true; this.currentIndex=clamp(this,this.currentIndex); const view=document.getElementById('qr-send-active-view'); if(view)view.hidden=false; render(this); sync(this); };
-        tx.pause=function(){ stopTimer(this); this.paused=true; sync(this); };
-        tx.resume=function(){ if(!this.running||!this.initialized||!this.frames?.length)return; stopTimer(this); this.paused=false; const tick=()=>{ if(!this.running||this.paused||!this.initialized||!this.frames?.length){stopTimer(this);sync(this);return;} render(this); this.currentIndex=(this.currentIndex+1)%this.frames.length; sync(this); this.timer=setTimeout(tick,1000/Math.max(1,Number(this.fps)||6)); }; tick(); };
-        tx.previousFrame=function(){select(this,this.currentIndex-1);}; tx.nextFrame=function(){select(this,this.currentIndex+1);}; tx.seekFrame=function(index){select(this,index);}; sync(tx);
+        if (!tx || !Array.isArray(tx.frames) || tx.__erikraftAnimatedControlsOwned) return;
+        tx.__erikraftAnimatedControlsOwned = true;
+        // qr-helper.js historically installed a second controller before this file.
+        // Take ownership here instead of respecting its legacy marker.
+        tx.__erikraftPlaybackControlsInstalled = true;
+        tx.initialized = false;
+        tx.start = function () {
+            if (!this.frames?.length) return;
+            stopTimer(this);
+            this.running = true;
+            this.paused = true;
+            this.initialized = false;
+            this.currentIndex = 0;
+            if (this.containerEl && window.ErikrafTDropQR?.destroy) window.ErikrafTDropQR.destroy(this.containerEl);
+            sync(this);
+        };
+        tx.initialize = function () {
+            if (!this.frames?.length) return;
+            stopTimer(this);
+            this.running = true;
+            this.paused = true;
+            this.initialized = true;
+            this.currentIndex = clamp(this, this.currentIndex);
+            showActive();
+            render(this);
+            sync(this);
+        };
+        tx.pause = function () {
+            stopTimer(this);
+            this.paused = true;
+            sync(this);
+        };
+        tx.resume = function () {
+            if (!this.running || !this.initialized || !this.frames?.length) return;
+            stopTimer(this);
+            this.paused = false;
+            const tick = () => {
+                if (!this.running || this.paused || !this.initialized || !this.frames?.length) {
+                    stopTimer(this);
+                    sync(this);
+                    return;
+                }
+                render(this);
+                this.currentIndex = (this.currentIndex + 1) % this.frames.length;
+                sync(this);
+                this.timer = setTimeout(tick, 1000 / Math.max(1, Number(this.fps) || 6));
+            };
+            tick();
+        };
+        tx.previousFrame = function () { select(this, this.currentIndex - 1); };
+        tx.nextFrame = function () { select(this, this.currentIndex + 1); };
+        tx.seekFrame = function (index) { select(this, index); };
+        sync(tx);
     };
-    const makeButton=(id,text,label,handler,template)=>{ let b=document.getElementById(id); if(b)return b; b=template.cloneNode(true); b.id=id; b.type='button'; b.removeAttribute('data-i18n-key'); b.textContent=text; b.setAttribute('aria-label',label); b.title=label; b.hidden=false; b.addEventListener('click',handler); return b; };
-    const setup=tx=>{
-        const buttons=document.getElementById(IDS.activeButtons), pause=document.getElementById(IDS.pause); if(!buttons||!pause||!tx)return false;
+    const makeButton = (id, text, label, handler, template) => {
+        let button = document.getElementById(id);
+        if (button) return button;
+        button = template.cloneNode(true);
+        button.id = id;
+        button.type = 'button';
+        button.removeAttribute('data-i18n-key');
+        button.textContent = text;
+        button.setAttribute('aria-label', label);
+        button.title = label;
+        button.onclick = handler;
+        return button;
+    };
+    const setup = tx => {
+        const buttons = document.getElementById(IDS.activeButtons);
+        const pause = document.getElementById(IDS.pause);
+        if (!buttons || !pause || !tx) return false;
         install(tx);
-        const init=makeButton(IDS.initialize,'Inicializar','Inicializar QR animado',()=>getTransmitter()?.initialize?.(),pause); if(!init.parentNode)buttons.insertBefore(init,buttons.firstElementChild);
-        const prev=makeButton(IDS.previous,'Anterior','Mostrar QR anterior',()=>getTransmitter()?.previousFrame?.(),pause); if(!prev.parentNode)buttons.insertBefore(prev,buttons.firstElementChild);
-        const next=makeButton(IDS.next,'Próximo','Mostrar próximo QR',()=>getTransmitter()?.nextFrame?.(),pause); if(!next.parentNode)buttons.insertBefore(next,pause.nextSibling);
-        if (!pause.dataset.erikraftControlCapture) { pause.dataset.erikraftControlCapture='true'; pause.addEventListener('click', event => { event.preventDefault(); event.stopImmediatePropagation(); const t=getTransmitter(); if(!t?.initialized)return; t.paused?t.resume():t.pause(); sync(t); }, true); }
-        if(!document.getElementById(IDS.seek)){
-            const w=document.createElement('div'); w.id=IDS.seekWrapper; w.className='fw column gap-1'; w.style.cssText='width:100%;margin:8px 0 0;';
-            const s=document.createElement('input'); s.type='range'; s.id=IDS.seek; s.className='fw'; s.style.cssText='width:100%;accent-color:#0d6efd;cursor:pointer;touch-action:pan-x;'; s.setAttribute('aria-label','Posição do QR animado'); s.addEventListener('input',e=>getTransmitter()?.seekFrame?.(Number(e.target.value))); w.appendChild(s); buttons.parentNode.insertBefore(w,buttons);
+        const init = makeButton(IDS.initialize, 'Inicializar', 'Inicializar QR animado', () => getTransmitter()?.initialize?.(), pause);
+        if (init && !init.parentNode) buttons.insertBefore(init, buttons.firstElementChild);
+        const prev = makeButton(IDS.previous, 'Anterior', 'Mostrar QR anterior', () => getTransmitter()?.previousFrame?.(), pause);
+        if (prev && !prev.parentNode) buttons.insertBefore(prev, buttons.firstElementChild);
+        const next = makeButton(IDS.next, 'Próximo', 'Mostrar próximo QR', () => getTransmitter()?.nextFrame?.(), pause);
+        if (next && !next.parentNode) buttons.insertBefore(next, pause.nextSibling);
+        if (!pause.dataset.erikraftControlCapture) {
+            pause.dataset.erikraftControlCapture = 'true';
+            pause.addEventListener('click', event => {
+                event.preventDefault();
+                event.stopImmediatePropagation();
+                const current = getTransmitter();
+                if (!current?.initialized) return;
+                current.paused ? current.resume() : current.pause();
+                sync(current);
+            }, true);
         }
-        if(!document.getElementById(IDS.frameInput)){
-            const g=document.createElement('div'); g.id=IDS.frameGroup; g.className='row center gap-2'; g.style.cssText='width:100%;justify-content:center;margin:8px 0 0;flex-wrap:wrap;';
-            const i=document.createElement('input'); i.type='number'; i.id=IDS.frameInput; i.className='btn btn-rounded btn-grey'; i.min='1'; i.step='1'; i.inputMode='numeric'; i.style.cssText='width:min(90px,24vw);text-align:center;'; i.setAttribute('aria-label','Número do QR');
-            const go=document.createElement('button'); go.type='button'; go.id=IDS.frameGo; go.className='btn btn-rounded btn-grey'; go.textContent='Ir'; go.setAttribute('aria-label','Ir para o QR informado'); go.title='Ir para o QR informado';
-            const goFrame=()=>{const v=Number.parseInt(i.value,10);if(Number.isFinite(v))getTransmitter()?.seekFrame?.(v-1);}; go.onclick=goFrame; i.addEventListener('keydown',e=>{if(e.key==='Enter'){e.preventDefault();goFrame();}}); g.append(i,go); buttons.parentNode.insertBefore(g,buttons);
+        if (!document.getElementById(IDS.seek)) {
+            const wrapper = document.createElement('div');
+            wrapper.id = IDS.seekWrapper;
+            wrapper.className = 'fw column gap-1';
+            wrapper.style.cssText = 'width:100%;margin:8px 0 0;';
+            const seek = document.createElement('input');
+            seek.type = 'range';
+            seek.id = IDS.seek;
+            seek.className = 'fw';
+            seek.style.cssText = 'width:100%;accent-color:#0d6efd;cursor:pointer;touch-action:pan-x;';
+            seek.setAttribute('aria-label', 'Posição do QR animado');
+            seek.addEventListener('input', event => getTransmitter()?.seekFrame?.(Number(event.target.value)));
+            wrapper.appendChild(seek);
+            buttons.parentNode.insertBefore(wrapper, buttons);
         }
-        sync(tx); return true;
+        if (!document.getElementById(IDS.frameInput)) {
+            const group = document.createElement('div');
+            group.id = IDS.frameGroup;
+            group.className = 'row center gap-2';
+            group.style.cssText = 'width:100%;justify-content:center;margin:8px 0 0;flex-wrap:wrap;';
+            const input = document.createElement('input');
+            input.type = 'number';
+            input.id = IDS.frameInput;
+            input.className = 'btn btn-rounded btn-grey';
+            input.min = '1';
+            input.step = '1';
+            input.inputMode = 'numeric';
+            input.style.cssText = 'width:min(90px,24vw);text-align:center;box-sizing:border-box;';
+            input.setAttribute('aria-label', 'Número do QR');
+            const go = document.createElement('button');
+            go.type = 'button';
+            go.id = IDS.frameGo;
+            go.className = 'btn btn-rounded btn-grey';
+            go.textContent = 'Ir';
+            go.setAttribute('aria-label', 'Ir para o QR informado');
+            go.title = 'Ir para o QR informado';
+            const goFrame = () => {
+                const value = Number.parseInt(input.value, 10);
+                if (Number.isFinite(value)) getTransmitter()?.seekFrame?.(value - 1);
+            };
+            go.onclick = goFrame;
+            input.addEventListener('keydown', event => {
+                if (event.key === 'Enter') {
+                    event.preventDefault();
+                    goFrame();
+                }
+            });
+            group.append(input, go);
+            buttons.parentNode.insertBefore(group, buttons);
+        }
+        sync(tx);
+        return true;
     };
-    const tryInstall=()=>{const tx=getTransmitter();if(!tx)return false;setup(tx);return !!tx.__erikraftRuntimeControlsInstalled;};
-    let attempts=0; const timer=setInterval(()=>{if(tryInstall()||++attempts>=300)clearInterval(timer);},100);
-    if(document.readyState==='loading')document.addEventListener('DOMContentLoaded',tryInstall,{once:true});else tryInstall();
+    const tryInstall = () => {
+        const tx = getTransmitter();
+        if (!tx) return false;
+        setup(tx);
+        return !!tx.__erikraftAnimatedControlsOwned;
+    };
+    let attempts = 0;
+    const timer = setInterval(() => {
+        if (tryInstall() || ++attempts >= 300) clearInterval(timer);
+    }, 100);
+    if (document.readyState === 'loading') document.addEventListener('DOMContentLoaded', tryInstall, { once: true });
+    else tryInstall();
 })();

--- a/public/scripts/animated-qr-controls.js
+++ b/public/scripts/animated-qr-controls.js
@@ -31,7 +31,10 @@
         const buttons = document.getElementById(IDS.activeButtons);
         const canvas = document.getElementById('qr-send-canvas-container');
         if (view) view.hidden = false;
-        if (buttons) buttons.hidden = false;
+        if (buttons) {
+            buttons.hidden = false;
+            buttons.removeAttribute('hidden');
+        }
         if (canvas) canvas.hidden = false;
     };
     const render = tx => {
@@ -43,21 +46,30 @@
         }
         tx.currentIndex = clamp(tx, tx.currentIndex);
         showActive();
-        qr.render(tx.containerEl, tx.frames[tx.currentIndex], {
-            width: 300,
-            height: 300,
-            animatedTransfer: true
-        });
-        if (typeof tx.onProgress === 'function') {
-            tx.onProgress({
-                currentIndex: tx.currentIndex,
-                totalFrames: tx.frames.length,
-                numBaseChunks: tx.numBaseChunks,
-                fps: tx.fps,
-                totalSize: tx.totalSize,
-                fileName: tx.metadata?.name || 'Data',
-                progressPct: Math.min(100, Math.round(((tx.currentIndex + 1) / tx.frames.length) * 100))
+        try {
+            qr.render(tx.containerEl, tx.frames[tx.currentIndex], {
+                width: 300,
+                height: 300,
+                animatedTransfer: true
             });
+        } catch (error) {
+            console.error('[Animated QR] Frame render failed:', error);
+            return false;
+        }
+        if (typeof tx.onProgress === 'function') {
+            try {
+                tx.onProgress({
+                    currentIndex: tx.currentIndex,
+                    totalFrames: tx.frames.length,
+                    numBaseChunks: tx.numBaseChunks,
+                    fps: tx.fps,
+                    totalSize: tx.totalSize,
+                    fileName: tx.metadata?.name || 'Data',
+                    progressPct: Math.min(100, Math.round(((tx.currentIndex + 1) / tx.frames.length) * 100))
+                });
+            } catch (error) {
+                console.warn('[Animated QR] Progress callback failed:', error);
+            }
         }
         return true;
     };
@@ -65,6 +77,11 @@
         if (!tx?.frames?.length) return;
         tx.currentIndex = clamp(tx, tx.currentIndex);
         const total = tx.frames.length;
+        const buttons = document.getElementById(IDS.activeButtons);
+        if (buttons) {
+            buttons.hidden = false;
+            buttons.removeAttribute('hidden');
+        }
         const seek = document.getElementById(IDS.seek);
         if (seek) {
             seek.min = '0';
@@ -85,6 +102,10 @@
         }
         const init = document.getElementById(IDS.initialize);
         if (init) init.hidden = !!tx.initialized;
+        const previous = document.getElementById(IDS.previous);
+        if (previous) previous.disabled = !tx.initialized;
+        const next = document.getElementById(IDS.next);
+        if (next) next.disabled = !tx.initialized;
         const pause = document.getElementById(IDS.pause);
         if (pause) {
             pause.textContent = tx.paused ? 'Play' : 'Pausar';
@@ -93,6 +114,8 @@
             pause.title = tx.paused ? 'Play' : 'Pausar';
             pause.disabled = !tx.initialized;
         }
+        const go = document.getElementById(IDS.frameGo);
+        if (go) go.disabled = !tx.initialized;
     };
     const select = (tx, index) => {
         if (!tx?.initialized || !tx.frames?.length) return;
@@ -106,8 +129,8 @@
     const install = tx => {
         if (!tx || !Array.isArray(tx.frames) || tx.__erikraftAnimatedControlsOwned) return;
         tx.__erikraftAnimatedControlsOwned = true;
-        // qr-helper.js historically installed a second controller before this file.
-        // Take ownership here instead of respecting its legacy marker.
+        // qr-helper.js has a legacy controller loaded before this file. Do not
+        // honor its marker: this controller is the final owner of playback.
         tx.__erikraftPlaybackControlsInstalled = true;
         tx.initialized = false;
         tx.start = function () {
@@ -128,7 +151,9 @@
             this.initialized = true;
             this.currentIndex = clamp(this, this.currentIndex);
             showActive();
-            render(this);
+            if (!render(this)) {
+                this.initialized = false;
+            }
             sync(this);
         };
         tx.pause = function () {
@@ -146,7 +171,11 @@
                     sync(this);
                     return;
                 }
-                render(this);
+                if (!render(this)) {
+                    this.paused = true;
+                    sync(this);
+                    return;
+                }
                 this.currentIndex = (this.currentIndex + 1) % this.frames.length;
                 sync(this);
                 this.timer = setTimeout(tick, 1000 / Math.max(1, Number(this.fps) || 6));
@@ -176,6 +205,12 @@
         const pause = document.getElementById(IDS.pause);
         if (!buttons || !pause || !tx) return false;
         install(tx);
+        // Frames are prepared before playback. Make the complete control row
+        // visible immediately; only actions that require initialization are disabled.
+        if (tx.frames?.length) {
+            buttons.hidden = false;
+            buttons.removeAttribute('hidden');
+        }
         const init = makeButton(IDS.initialize, 'Inicializar', 'Inicializar QR animado', () => getTransmitter()?.initialize?.(), pause);
         if (init && !init.parentNode) buttons.insertBefore(init, buttons.firstElementChild);
         const prev = makeButton(IDS.previous, 'Anterior', 'Mostrar QR anterior', () => getTransmitter()?.previousFrame?.(), pause);

--- a/public/styles/animated-qr-spacing.css
+++ b/public/styles/animated-qr-spacing.css
@@ -61,11 +61,11 @@
 .erikraft-qr-dialog .font-body2,
 .erikraft-qr-dialog .font-caption { overflow-wrap: anywhere; }
 @media (max-width: 480px) {
-    .erikraft-qr-dialog .erikraft-qr-paper { max-height: calc(100vh - 12px); max-width: 98vw; }
+    .erikraft-qr-dialog .erikraft-qr-paper { max-height: calc(100dvh - 12px); max-width: 98vw; width: 98vw; }
     .erikraft-qr-dialog .erikraft-qr-paper > .row.center:has(.dialog-title) { padding: 12px 14px; }
     .erikraft-qr-dialog .erikraft-qr-paper > .row.center.p-3 { padding: 12px; }
     .erikraft-qr-dialog .erikraft-qr-paper > .erikraft-qr-btn-row,
-    .erikraft-qr-dialog .erikraft-qr-paper > .btn-row { padding: 8px 12px 12px; gap: 8px; }
+    .erikraft-qr-dialog .erikraft-qr-paper > .btn-row { padding: 8px 12px max(12px, env(safe-area-inset-bottom)); gap: 8px; }
     #animated-qr-send-dialog #qr-send-compose-view > .column { gap: 16px; }
     #animated-qr-main-dialog .erikraft-qr-card-send > .row { width: 100%; flex-wrap: wrap; }
     #animated-qr-send-dialog #qr-send-text-input { min-height: 110px; font-size: 16px; }
@@ -78,5 +78,14 @@
     #animated-qr-send-dialog #qr-send-text-container > .row > *, #animated-qr-send-dialog #qr-send-file-container > .row > * { min-width: 0; max-width: 100%; }
 }
 @media (min-width: 481px) {
-    #animated-qr-send-dialog #qr-send-active-buttons { max-height: 40vh; overflow-y: auto; }
+    #animated-qr-send-dialog #qr-send-active-buttons { max-height: none; overflow: visible; }
+}
+@media (min-width: 481px) and (max-height: 760px) {
+    .erikraft-qr-dialog .erikraft-qr-paper { max-height: calc(100vh - 16px); }
+    #animated-qr-send-dialog #qr-send-active-view { overflow: visible; }
+}
+@media (max-width: 360px) {
+    #animated-qr-send-dialog #qr-send-canvas-container { width: min(260px, 72vw); height: min(260px, 72vw); }
+    #animated-qr-send-dialog #qr-send-active-view > .column { gap: 10px; }
+    #animated-qr-send-dialog #qr-send-file-info { font-size: 0.9rem; }
 }


### PR DESCRIPTION
## Root-cause fixes

The previous Animated QR change did not actually take ownership of the transmitter because `qr-helper.js` installs a legacy controller first and sets `__erikraftPlaybackControlsInstalled`. The later runtime therefore skipped installation. This PR fixes that instead of adding another competing controller.

## Changes
- Take explicit ownership of the Animated QR transmitter from the final runtime controller.
- Keep `start()` prepared/paused; it does not render or autoplay.
- `Inicializar` renders the first QR and leaves it paused for the receiver to start reading.
- Keep one Play/Pausar control; legacy click handling is intercepted safely.
- Previous/Next navigation.
- Blue seek bar with direct frame seeking.
- Numeric frame selection + Ir.
- Clamp all frame indices.
- Stop previous timers before starting another playback loop.
- Render through the confirmed `window.ErikrafTDropQR` global with `animatedTransfer: true`.
- Keep the full active control row visible once frames are prepared, instead of leaving only Fechar visible.
- Disable only controls that require initialization.
- Improve desktop dialog height/scroll behavior.
- Improve mobile/Redmi-class narrow viewport sizing, safe-area spacing and button wrapping.
- Reduce QR container sizing on very narrow screens so it cannot force horizontal overflow.
- Improve Animated QR text/file compose sizing without changing transfer protocol.

## Decimen reference analysis
The vendored `References/decimen-optical-transfer` was reviewed as a modern optical-transfer reference. Its current design uses configurable transmission FPS, bytes/frame, QR error correction, tiled layouts, display size, fullscreen QR and a fountain-coded stream; its documented benchmarks are substantially faster than the current ErikrafT implementation. We use it as an architectural/UX reference only and do not copy AGPL implementation code into Drop.

The existing Drop wire format/FEC/CRC32/SHA-256/compression implementation is intentionally left unchanged in this PR.

## Validation
- Audited current `master` commit and the actual script loading order.
- Audited `qr-helper.js`, `erikraft-qr.js`, `animated-qr-controls.js` and Animated QR spacing CSS.
- Confirmed `window.ErikrafTDropQR` is explicitly exported by `qr-helper.js`.
- Confirmed `animated-qr-controls.js` loads after `erikraft-qr.js`.
- Static control-flow validation completed.
- Browser/device validation is still required on PC, laptop, Android/Redmi 9C and a narrow mobile viewport before merge; no claim of literal zero runtime bugs is made without that test.

## Deploy
Do not merge automatically. After review/merge, verify both Render and the fallback Vercel deployment are on the resulting `master` commit.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Improved animated QR controls, including clearer active-state visibility and more consistent playback controls.
  * Added improved slider accessibility labeling and responsive behavior across screen sizes.
* **Bug Fixes**
  * Improved error handling during QR frame rendering and progress updates to prevent broken playback states.
  * Controls now remain appropriately disabled until the QR animation is ready.
* **Style**
  * Improved QR dialog sizing on mobile, including safer spacing around device screen edges.
  * Improved layout for shorter desktop screens and narrow mobile displays.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->