### PR TITLE
Fix Animated QR UI layout, mobile controls, and themes

### DIFF
--- a/public/index.html
+++ b/public/index.html
@@ -1722,15 +1722,16 @@
                                 </select>
                             </div>
                         </div>
-                    </div>
-                </div>
 
-                <div id="qr-send-active-buttons" class="btn-row wrap erikraft-qr-btn-row" hidden>
-                    <button id="qr-send-next-btn" type="button" class="btn btn-rounded btn-grey">Próximo</button>
-                    <button id="qr-send-pause-btn" type="button" class="btn btn-rounded btn-grey" data-i18n-key="dialogs.animated-qr-pause">Pausar</button>
-                    <button id="qr-send-previous-btn" type="button" class="btn btn-rounded btn-grey">Anterior</button>
-                    <button id="qr-send-back-btn" type="button" class="btn btn-rounded btn-red" data-i18n-key="dialogs.animated-qr-back">Voltar</button>
-                    <button id="qr-send-close-btn" type="button" class="btn btn-rounded btn-red" close data-i18n-key="dialogs.close">Fechar</button>
+                        <!-- Controls inside column fw gap-3 -->
+                        <div id="qr-send-controls-group" class="fw column gap-2 mt-2">
+                            <button id="qr-send-next-btn" type="button" class="btn btn-rounded btn-grey fw">Próximo</button>
+                            <button id="qr-send-pause-btn" type="button" class="btn btn-rounded btn-grey fw" data-i18n-key="dialogs.animated-qr-pause">Pausar</button>
+                            <button id="qr-send-previous-btn" type="button" class="btn btn-rounded btn-grey fw">Anterior</button>
+                            <button id="qr-send-back-btn" type="button" class="btn btn-rounded btn-red fw" data-i18n-key="dialogs.animated-qr-back">Voltar</button>
+                            <button id="qr-send-close-btn" type="button" class="btn btn-rounded btn-red fw" close data-i18n-key="dialogs.close">Fechar</button>
+                        </div>
+                    </div>
                 </div>
             </x-paper>
         </x-background>

--- a/public/scripts/animated-qr-controls.js
+++ b/public/scripts/animated-qr-controls.js
@@ -2,7 +2,7 @@
     'use strict';
 
     const IDS = {
-        activeButtons: 'qr-send-active-buttons', pause: 'qr-send-pause-btn',
+        activeButtons: 'qr-send-controls-group', pause: 'qr-send-pause-btn',
         previous: 'qr-send-previous-btn', next: 'qr-send-next-btn', seek: 'qr-send-frame-seek',
         frameInput: 'qr-send-frame-input', frameGo: 'qr-send-frame-go-btn', frameGroup: 'qr-send-frame-input-group',
         seekWrapper: 'qr-send-frame-seek-wrapper', bytes: 'qr-send-bytes-per-frame', ecc: 'qr-send-ecc-level',
@@ -27,7 +27,7 @@
         style.textContent = `
 #animated-qr-send-dialog .erikraft-qr-paper{display:flex;flex-direction:column;min-height:0;width:min(720px,calc(100vw - 20px));max-width:720px;max-height:calc(100dvh - 16px);overflow:hidden;box-sizing:border-box}
 #animated-qr-send-dialog #qr-send-active-view,#animated-qr-send-dialog #qr-send-compose-view{flex:1 1 auto;min-height:0;max-height:none;overflow-y:auto;overflow-x:hidden;width:100%;box-sizing:border-box;overscroll-behavior:contain;-webkit-overflow-scrolling:touch;scrollbar-gutter:stable}
-#animated-qr-send-dialog #qr-send-active-buttons,#animated-qr-send-dialog #qr-send-compose-buttons{position:relative;flex:0 0 auto;z-index:2;width:100%;box-sizing:border-box;margin:0;padding:10px max(12px,2vw) max(12px,env(safe-area-inset-bottom));background:var(--paper-color,var(--background-color,#fff));border-top:1px solid color-mix(in srgb,currentColor 12%,transparent);overflow:visible;justify-content:center;align-items:center}
+#animated-qr-send-dialog #qr-send-compose-buttons{position:relative;flex:0 0 auto;z-index:2;width:100%;box-sizing:border-box;margin:0;padding:10px max(12px,2vw) max(12px,env(safe-area-inset-bottom));background:var(--paper-color,var(--background-color,#fff));border-top:1px solid color-mix(in srgb,currentColor 12%,transparent);overflow:visible;justify-content:center;align-items:center}
 #animated-qr-send-dialog #qr-send-active-view>.column{min-width:0;width:100%}
 #animated-qr-send-dialog #qr-send-canvas-container{width:min(320px,calc(100vw - 64px));min-height:220px;margin:4px auto;flex:0 0 auto;display:flex;align-items:center;justify-content:center;overflow:hidden;box-sizing:border-box}
 #animated-qr-send-dialog #qr-send-canvas-container.layout-1{width:min(300px,calc(100vw - 64px));height:min(300px,calc(100vw - 64px))}
@@ -35,15 +35,16 @@
 #animated-qr-send-dialog #qr-send-canvas-container.layout-4{display:grid;grid-template-columns:1fr 1fr;grid-template-rows:1fr 1fr;gap:6px;width:min(340px,calc(100vw - 32px));height:auto}
 #animated-qr-send-dialog .qr-tile{display:flex;flex-direction:column;align-items:center;justify-content:center;box-sizing:border-box;width:100%;background:#ffffff;padding:4px;border-radius:8px;box-shadow:0 1px 4px rgba(0,0,0,0.12)}
 #animated-qr-send-dialog .qr-tile svg,#animated-qr-send-dialog .qr-tile canvas,#animated-qr-send-dialog #qr-send-canvas-container>svg,#animated-qr-send-dialog #qr-send-canvas-container>canvas{display:block;width:100%!important;height:100%!important;max-width:100%;max-height:100%}
-#animated-qr-send-dialog #qr-send-active-buttons>.btn{flex:0 1 auto;min-width:120px;max-width:220px;margin:0}
+#animated-qr-send-dialog #qr-send-controls-group{width:100%;box-sizing:border-box;display:flex;flex-direction:column;gap:10px;margin-top:12px}
+#animated-qr-send-dialog #qr-send-controls-group > .btn{width:100%;margin:0;min-height:44px}
 #animated-qr-send-dialog #qr-send-frame-seek-wrapper,#animated-qr-send-dialog #qr-send-frame-input-group{width:100%;box-sizing:border-box}
 #animated-qr-send-dialog #qr-send-frame-seek{width:100%;min-width:0;height:8px;touch-action:pan-x;accent-color:#0d6efd}
 #animated-qr-send-dialog #qr-send-frame-input-group{display:flex;flex-wrap:wrap;justify-content:center;gap:8px}
 #animated-qr-send-dialog #qr-send-frame-input{width:96px;min-height:40px;box-sizing:border-box;text-align:center}
 #animated-qr-send-dialog #qr-send-frame-go-btn{min-height:40px}
 #animated-qr-send-dialog #qr-send-bytes-per-frame,#animated-qr-send-dialog #qr-send-ecc-level,#animated-qr-send-dialog #qr-send-layout,#animated-qr-send-dialog #qr-send-display-size{min-width:0;max-width:100%;box-sizing:border-box}
-@media(max-width:600px){#animated-qr-send-dialog .erikraft-qr-paper{width:calc(100vw - 12px);max-height:calc(100dvh - 8px)}#animated-qr-send-dialog #qr-send-active-view,#animated-qr-send-dialog #qr-send-compose-view{padding:12px!important}#animated-qr-send-dialog #qr-send-active-buttons,#animated-qr-send-dialog #qr-send-compose-buttons{padding-left:10px;padding-right:10px;gap:8px}#animated-qr-send-dialog #qr-send-active-buttons>.btn,#animated-qr-send-dialog #qr-send-compose-buttons>.btn{flex:1 1 calc(50% - 8px);min-width:0;max-width:none;min-height:44px}#animated-qr-send-dialog #qr-send-canvas-container{width:min(280px,calc(100vw - 48px));height:min(280px,calc(100vw - 48px))}}
-@media(max-width:360px){#animated-qr-send-dialog #qr-send-active-buttons>.btn,#animated-qr-send-dialog #qr-send-compose-buttons>.btn{flex-basis:100%}#animated-qr-send-dialog #qr-send-canvas-container{width:min(240px,calc(100vw - 40px));height:min(240px,calc(100vw - 40px))}}
+@media(max-width:600px){#animated-qr-send-dialog .erikraft-qr-paper{width:calc(100vw - 12px);max-height:calc(100dvh - 8px)}#animated-qr-send-dialog #qr-send-active-view,#animated-qr-send-dialog #qr-send-compose-view{padding:12px!important}#animated-qr-send-dialog #qr-send-compose-buttons{padding-left:10px;padding-right:10px;gap:8px}#animated-qr-send-dialog #qr-send-compose-buttons>.btn{flex:1 1 calc(50% - 8px);min-width:0;max-width:none;min-height:44px}#animated-qr-send-dialog #qr-send-canvas-container{width:min(280px,calc(100vw - 48px));height:min(280px,calc(100vw - 48px))}}
+@media(max-width:360px){#animated-qr-send-dialog #qr-send-compose-buttons>.btn{flex-basis:100%}#animated-qr-send-dialog #qr-send-canvas-container{width:min(240px,calc(100vw - 40px));height:min(240px,calc(100vw - 40px))}}
         `;
         document.head.appendChild(style);
     }
@@ -145,8 +146,8 @@
             backBtn.onclick=(e)=>{
                 const t=getTransmitter(); if(t){ t.pause(); }
                 const comp=getEl('qr-send-compose-view'), act=getEl('qr-send-active-view'),
-                      compBtns=getEl('qr-send-compose-buttons'), actBtns=getEl(IDS.activeButtons);
-                if(act) act.hidden=true; if(actBtns) actBtns.hidden=true;
+                      compBtns=getEl('qr-send-compose-buttons');
+                if(act) act.hidden=true;
                 if(comp) comp.hidden=false; if(compBtns) compBtns.hidden=false;
             };
         }

--- a/public/scripts/ui.js
+++ b/public/scripts/ui.js
@@ -3610,7 +3610,7 @@ class AnimatedQRSendDialog extends Dialog {
         this.$composeView = this.$el.querySelector('#qr-send-compose-view');
         this.$composeButtons = this.$el.querySelector('#qr-send-compose-buttons');
         this.$activeView = this.$el.querySelector('#qr-send-active-view');
-        this.$activeButtons = this.$el.querySelector('#qr-send-active-buttons');
+        this.$activeButtons = this.$el.querySelector('#qr-send-controls-group');
 
         // Text composition elements
         this.$textContainer = this.$el.querySelector('#qr-send-text-container');

--- a/public/styles/animated-qr-spacing.css
+++ b/public/styles/animated-qr-spacing.css
@@ -75,33 +75,70 @@ body.dark-theme .btn-red:hover, body.dark-theme .btn-red:focus {
 #animated-qr-send-dialog #qr-send-frame-go-btn { min-height: 40px; }
 #animated-qr-send-dialog #qr-send-initialize-btn { min-width: 120px; }
 #animated-qr-send-dialog #qr-send-play-btn { display: none !important; }
-#animated-qr-send-dialog #qr-send-active-view:not([hidden]) ~ #qr-send-active-buttons[hidden] { display: flex !important; }
-#animated-qr-send-dialog #qr-send-active-view:not([hidden]) ~ #qr-send-active-buttons { flex-wrap: wrap; justify-content: center; align-items: center; width: 100%; box-sizing: border-box; }
-#animated-qr-send-dialog #qr-send-active-buttons {
+#animated-qr-send-dialog #qr-send-controls-group {
     display: flex;
-    flex-wrap: wrap;
-    justify-content: center;
-    align-items: center;
-    gap: 8px;
+    flex-direction: column;
+    gap: 10px;
+    width: 100%;
+    box-sizing: border-box;
+    margin-top: 12px;
 }
-#animated-qr-send-dialog #qr-send-active-buttons > .btn {
-    flex: 1 1 calc(20% - 8px);
-    min-width: 90px;
+#animated-qr-send-dialog #qr-send-controls-group > .btn {
+    width: 100%;
     margin: 0;
+    min-height: 44px;
 }
+
+/* Theme support for dialogs */
+body.light-theme .erikraft-qr-dialog .erikraft-qr-paper,
+body:not(.dark-theme) .erikraft-qr-dialog .erikraft-qr-paper {
+    background-color: #ffffff;
+    color: #212529;
+}
+
+body.dark-theme .erikraft-qr-dialog .erikraft-qr-paper {
+    background-color: #1e1e1e;
+    color: #f8f9fa;
+}
+
+@media (prefers-color-scheme: dark) {
+    body:not(.light-theme):not(.dark-theme) .erikraft-qr-dialog .erikraft-qr-paper {
+        background-color: #1e1e1e;
+        color: #f8f9fa;
+    }
+}
+
 body.light-theme #animated-qr-send-dialog textarea,
 body.light-theme #animated-qr-send-dialog select,
-body.light-theme #animated-qr-send-dialog input[type="number"] {
+body.light-theme #animated-qr-send-dialog input,
+body.light-theme #qr-scanner-dialog input,
+body:not(.dark-theme) #animated-qr-send-dialog textarea,
+body:not(.dark-theme) #animated-qr-send-dialog select,
+body:not(.dark-theme) #animated-qr-send-dialog input,
+body:not(.dark-theme) #qr-scanner-dialog input {
     background-color: #f8f9fa;
     color: #212529;
     border: 1px solid #ced4da;
 }
+
 body.dark-theme #animated-qr-send-dialog textarea,
 body.dark-theme #animated-qr-send-dialog select,
-body.dark-theme #animated-qr-send-dialog input[type="number"] {
+body.dark-theme #animated-qr-send-dialog input,
+body.dark-theme #qr-scanner-dialog input {
     background-color: #2b3035;
     color: #f8f9fa;
     border: 1px solid #495057;
+}
+
+@media (prefers-color-scheme: dark) {
+    body:not(.light-theme):not(.dark-theme) #animated-qr-send-dialog textarea,
+    body:not(.light-theme):not(.dark-theme) #animated-qr-send-dialog select,
+    body:not(.light-theme):not(.dark-theme) #animated-qr-send-dialog input,
+    body:not(.light-theme):not(.dark-theme) #qr-scanner-dialog input {
+        background-color: #2b3035;
+        color: #f8f9fa;
+        border: 1px solid #495057;
+    }
 }
 #animated-qr-receive-dialog #qr-receive-scanner-view { gap: 14px; min-width: 0; }
 #animated-qr-receive-dialog .erikraft-qr-camera-wrapper { margin-bottom: 2px; max-width: 100%; }
@@ -130,12 +167,7 @@ body.dark-theme #animated-qr-send-dialog input[type="number"] {
     #animated-qr-send-dialog #qr-send-frame-input-group { flex-wrap: wrap; }
     #animated-qr-send-dialog #qr-send-frame-input { width: min(110px, 34vw); }
     #animated-qr-send-dialog #qr-send-canvas-container { width: min(280px, 85vw); height: min(280px, 85vw); min-width: 180px; min-height: 180px; max-width: 280px; max-height: 280px; }
-    #animated-qr-send-dialog #qr-send-active-view:not([hidden]) ~ #qr-send-active-buttons { padding-bottom: max(12px, env(safe-area-inset-bottom)); }
-    #animated-qr-send-dialog #qr-send-active-view:not([hidden]) ~ #qr-send-active-buttons > .btn { flex: 1 1 100%; min-height: 44px; }
     #animated-qr-send-dialog #qr-send-text-container > .row > *, #animated-qr-send-dialog #qr-send-file-container > .row > * { min-width: 0; max-width: 100%; }
-}
-@media (min-width: 481px) {
-    #animated-qr-send-dialog #qr-send-active-buttons { max-height: none; overflow: visible; }
 }
 @media (min-width: 481px) and (max-height: 760px) {
     .erikraft-qr-dialog .erikraft-qr-paper { max-height: calc(100vh - 16px); }


### PR DESCRIPTION
Reorganized Animated QR Transfer controls into column fw gap-3 in the required order (Próximo, Play/Pause, Anterior, Voltar, Fechar) without fixed container overlays, fixed mobile touch scrolling, and unified theme support across Animated QR and QR Scanner dialogs.

---
*PR created automatically by Jules for task [1237563115645856987](https://jules.google.com/task/1237563115645856987) started by @erikraft*

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **UI Improvements**
  * Reorganized Animated QR Send controls into a full-width vertical button layout.
  * Improved light and dark theme support for the transfer dialog and its inputs.
  * Updated responsive styling for a more consistent experience across screen sizes.


<!-- end of auto-generated comment: release notes by coderabbit.ai -->