### PR TITLE
Fix: Animated QR file transfer canvas size

### DIFF
--- a/public/styles/animated-qr-spacing.css
+++ b/public/styles/animated-qr-spacing.css
@@ -17,7 +17,7 @@ body.dark-theme .btn-red {
 body.dark-theme .btn-red:hover, body.dark-theme .btn-red:focus {
     background-color: #b71c1c !important;
     color: #ffffff !important;
-    border-color: #a71d1d !important;
+    border-color: #a71c1c !important;
 }
 
 .erikraft-qr-dialog .erikraft-qr-paper {
@@ -319,5 +319,36 @@ body.dark-theme #animated-qr-main-dialog .erikraft-qr-btn-row {
     }
     #animated-qr-main-dialog .erikraft-qr-paper > .row.center.p-3 {
         padding-bottom: 20px;
+    }
+}
+
+/* File-transfer QR must use the available canvas box without overriding size controls. */
+#animated-qr-send-dialog #qr-send-file-info:not(:empty) ~ #qr-send-canvas-container {
+    min-width: 0;
+    min-height: 0;
+    width: min(420px, calc(100vw - 40px));
+    height: min(420px, calc(100vw - 40px));
+    max-width: calc(100% - 8px);
+    max-height: none;
+}
+#animated-qr-send-dialog #qr-send-file-info:not(:empty) ~ #qr-send-canvas-container > svg,
+#animated-qr-send-dialog #qr-send-file-info:not(:empty) ~ #qr-send-canvas-container > canvas {
+    display: block;
+    width: 100%;
+    height: 100%;
+    max-width: 100% !important;
+    max-height: 100% !important;
+    object-fit: contain;
+}
+@media (max-width: 480px) {
+    #animated-qr-send-dialog #qr-send-file-info:not(:empty) ~ #qr-send-canvas-container {
+        width: min(360px, calc(100vw - 32px));
+        height: min(360px, calc(100vw - 32px));
+    }
+}
+@media (max-width: 360px) {
+    #animated-qr-send-dialog #qr-send-file-info:not(:empty) ~ #qr-send-canvas-container {
+        width: min(300px, calc(100vw - 24px));
+        height: min(300px, calc(100vw - 24px));
     }
 }

--- a/public/styles/animated-qr-spacing.css
+++ b/public/styles/animated-qr-spacing.css
@@ -17,7 +17,7 @@ body.dark-theme .btn-red {
 body.dark-theme .btn-red:hover, body.dark-theme .btn-red:focus {
     background-color: #b71c1c !important;
     color: #ffffff !important;
-    border-color: #a71c1c !important;
+    border-color: #a71d1d !important;
 }
 
 .erikraft-qr-dialog .erikraft-qr-paper {


### PR DESCRIPTION
## Objetivo
Corrigir o tamanho visual do QR Code Animado durante a Transferência de Arquivo, mantendo a Transferência de Texto como está e sem quebrar os controles de tamanho Pequeno/Médio/Grande.

## Alteração
- Ajusta especificamente o canvas da Transferência de Arquivo quando `#qr-send-file-info` está preenchido.
- Faz SVG/Canvas ocupar corretamente a área disponível do `#qr-send-canvas-container`.
- Mantém limites responsivos para desktop, mobile e telas muito pequenas.
- Não força tamanho quando a aplicação já fornece um tamanho explícito no container, preservando a funcionalidade de Pequeno/Médio/Grande.

## Mantido
- Correção do conflito causado pelo `.row.center` e rolagem completa do modo Enviar.
- `#qr-send-canvas-container` continua acessível e não fica encoberto.
- Espaço inferior para alcançar os últimos controles.
- Correção da rolagem da tela de seleção Enviar/Receber.
- Tema Claro/Escuro/Automático de `btn-row row-reverse wrap erikraft-qr-btn-row` no diálogo Enviar/Receber.
- Cores específicas dos botões.
- JavaScript e lógica funcional do QR Animado inalterados.
- Diálogos Emparelhamento e Sala Pública Temporária inalterados.
- Alteração isolada em `public/styles/animated-qr-spacing.css`.

## Base
Branch criado diretamente do `master` mais recente: `63a126e51a95d7d61271091114579be90dbf97d0`.

A mudança efetiva desta PR é somente em `public/styles/animated-qr-spacing.css` (+31 linhas, sem remoções no diff final).