### PR TITLE
Fix: preserve Animated QR file size and background dimensions

### DIFF
--- a/public/scripts/qr-helper.js
+++ b/public/scripts/qr-helper.js
@@ -33,7 +33,15 @@ class ErikrafTDropQR {
         if (!isAnimatedTransfer && !this._logoState.attempted) this._ensureLogoLoaded(logoPath);
         if (container._qrInstance && typeof container._qrInstance.update === 'function') {
             try {
-                container._qrInstance.update({ data });
+                const updateOptions = { data };
+                // qr-code-styling's update() must receive width/height explicitly;
+                // otherwise an existing 280x280 instance keeps its original SVG
+                // background rect and ignores the animated transfer size control.
+                if (isAnimatedTransfer) {
+                    if (Number.isFinite(options.width)) updateOptions.width = options.width;
+                    if (Number.isFinite(options.height)) updateOptions.height = options.height;
+                }
+                container._qrInstance.update(updateOptions);
                 return container._qrInstance;
             } catch (err) {
                 console.warn('[QR Helper] Direct instance update failed, recreating:', err);


### PR DESCRIPTION
## Objetivo

Corrigir o tamanho da área branca (`<rect ... fill="#ffffff">`) do QR Code Animado durante a transferência de arquivos, sem alterar o comportamento visual que já está correto para transferência de texto.

## Causa identificada

No `public/scripts/animated-qr-controls.js`, o tamanho selecionado (`Pequeno`, `Médio`, `Grande`) é enviado ao renderer. Porém, em `public/scripts/qr-helper.js`, quando o QR Code já possui uma instância `QRCodeStyling`, o `update()` recebia somente `{ data }`. Assim, a instância SVG existente podia permanecer com a dimensão inicial (por exemplo, 280×280), mantendo também a área de fundo branca nessa dimensão e ignorando mudanças posteriores de tamanho.

## Correção

- Manter a instância existente do QR Code Animado e atualizar `width`/`height` junto com `data` quando o modo for transferência animada.
- Fazer isso somente para QR Codes Animados, preservando o comportamento dos QR Codes estáticos.
- Não alterar o protocolo, geração dos frames, FPS, ECC, layout 1/2/4 ou lógica de transferência.
- Não alterar `public/styles/animated-qr-spacing.css`; todos os ajustes de scroll, `.row.center`, temas e responsividade da PR anterior permanecem intactos.
- Preservar a funcionalidade `Tamanho`: `Pequeno`, `Médio` e `Grande`.
- Garantir que a dimensão do SVG e, consequentemente, a área branca interna do SVG sejam regeneradas/atualizadas de acordo com o tamanho selecionado.
- Preservar a responsividade em desktop, tablet e mobile, sem criar overflow horizontal ou impedir a rolagem vertical existente.
- Não modificar os diálogos `Emparelhamento` ou `Sala Pública Temporária`.

## Escopo

Alteração isolada em `public/scripts/qr-helper.js`, apenas na atualização de instâncias do QR Code Animado.

## Validação esperada

Verificar no fluxo de transferência de arquivo:
1. `Pequeno` mantém QR menor.
2. `Médio` mantém QR intermediário.
3. `Grande` realmente aumenta a área do SVG/background, incluindo o `<rect>` branco.
4. Alterar o tamanho depois que frames já foram renderizados atualiza a dimensão corretamente.
5. Transferência de texto continua visualmente igual.
6. Layouts 1, 2 e 4 continuam funcionando.
7. Mobile não perde a rolagem nem corta o `#qr-send-canvas-container`.
8. Nenhuma alteração é necessária nos scripts/protocolo de transmissão ou nos diálogos de referência.

Esta PR deve ser revisada como uma correção pontual de manutenção de código existente, evitando refatorações desnecessárias.