### PR TITLE
Fix: improve Animated QR file transfer size and responsive display

### DIFF
--- a/public/scripts/animated-qr-file-size.js
+++ b/public/scripts/animated-qr-file-size.js
@@ -70,14 +70,14 @@
         const style = document.createElement('style');
         style.id = 'erikraft-animated-qr-file-size-style';
         style.textContent = `
-#animated-qr-send-dialog #qr-send-canvas-container:has(+ *) {
+#animated-qr-send-dialog #qr-send-file-info:not(:empty) ~ #qr-send-canvas-container {
     width: min(var(--erikraft-file-qr-size, 320px), calc(100vw - 32px)) !important;
     height: min(var(--erikraft-file-qr-size, 320px), calc(100vw - 32px)) !important;
     max-width: calc(100vw - 32px) !important;
     max-height: calc(100vw - 32px) !important;
 }
 @media (max-width: 600px) {
-    #animated-qr-send-dialog #qr-send-canvas-container:has(+ *) {
+    #animated-qr-send-dialog #qr-send-file-info:not(:empty) ~ #qr-send-canvas-container {
         width: min(var(--erikraft-file-qr-size, 320px), calc(100vw - 24px)) !important;
         height: min(var(--erikraft-file-qr-size, 320px), calc(100vw - 24px)) !important;
         max-width: calc(100vw - 24px) !important;
@@ -85,7 +85,7 @@
     }
 }
 @media (max-width: 360px) {
-    #animated-qr-send-dialog #qr-send-canvas-container:has(+ *) {
+    #animated-qr-send-dialog #qr-send-file-info:not(:empty) ~ #qr-send-canvas-container {
         width: min(var(--erikraft-file-qr-size, 320px), calc(100vw - 20px)) !important;
         height: min(var(--erikraft-file-qr-size, 320px), calc(100vw - 20px)) !important;
         max-width: calc(100vw - 20px) !important;

--- a/public/scripts/animated-qr-file-size.js
+++ b/public/scripts/animated-qr-file-size.js
@@ -1,0 +1,121 @@
+(function setupAnimatedQRFileSizeDefaults() {
+    'use strict';
+
+    const FILE_INFO_ID = 'qr-send-file-info';
+    const DISPLAY_SIZE_ID = 'qr-send-display-size';
+    const CANVAS_ID = 'qr-send-canvas-container';
+    const DEFAULT_FILE_SIZE = 'large';
+    const SIZE_PX = { small: 220, medium: 280, large: 320 };
+
+    const getEl = id => document.getElementById(id);
+
+    function isFileTransferActive() {
+        const fileInfo = getEl(FILE_INFO_ID);
+        return !!fileInfo && !!fileInfo.textContent.trim();
+    }
+
+    function syncContainerSize() {
+        const select = getEl(DISPLAY_SIZE_ID);
+        const container = getEl(CANVAS_ID);
+        if (!select || !container || !isFileTransferActive()) return;
+
+        const requestedSize = SIZE_PX[select.value] || SIZE_PX[DEFAULT_FILE_SIZE];
+        container.style.setProperty('--erikraft-file-qr-size', `${requestedSize}px`);
+    }
+
+    function applyFileDefault() {
+        const select = getEl(DISPLAY_SIZE_ID);
+        if (!select || !isFileTransferActive()) return;
+
+        // Only choose Large automatically when the user has not explicitly
+        // changed the Tamanho control. Never override an explicit choice.
+        if (select.dataset.erikraftUserSizeSelection !== 'true') {
+            select.value = DEFAULT_FILE_SIZE;
+        }
+        syncContainerSize();
+    }
+
+    function bindSizeControl() {
+        const select = getEl(DISPLAY_SIZE_ID);
+        if (!select || select.dataset.erikraftFileSizeBound === 'true') return;
+
+        select.dataset.erikraftFileSizeBound = 'true';
+        select.addEventListener('change', () => {
+            select.dataset.erikraftUserSizeSelection = 'true';
+            syncContainerSize();
+        });
+    }
+
+    function resetWhenFileClears() {
+        const fileInfo = getEl(FILE_INFO_ID);
+        const select = getEl(DISPLAY_SIZE_ID);
+        if (!fileInfo || !select || fileInfo.dataset.erikraftFileSizeObserver === 'true') return;
+
+        fileInfo.dataset.erikraftFileSizeObserver = 'true';
+        const observer = new MutationObserver(() => {
+            if (fileInfo.textContent.trim()) {
+                bindSizeControl();
+                applyFileDefault();
+            } else {
+                delete select.dataset.erikraftUserSizeSelection;
+                const container = getEl(CANVAS_ID);
+                container?.style.removeProperty('--erikraft-file-qr-size');
+            }
+        });
+        observer.observe(fileInfo, { childList: true, characterData: true, subtree: true });
+    }
+
+    function injectResponsiveSizing() {
+        if (document.getElementById('erikraft-animated-qr-file-size-style')) return;
+        const style = document.createElement('style');
+        style.id = 'erikraft-animated-qr-file-size-style';
+        style.textContent = `
+#animated-qr-send-dialog #qr-send-canvas-container:has(+ *) {
+    width: min(var(--erikraft-file-qr-size, 320px), calc(100vw - 32px)) !important;
+    height: min(var(--erikraft-file-qr-size, 320px), calc(100vw - 32px)) !important;
+    max-width: calc(100vw - 32px) !important;
+    max-height: calc(100vw - 32px) !important;
+}
+@media (max-width: 600px) {
+    #animated-qr-send-dialog #qr-send-canvas-container:has(+ *) {
+        width: min(var(--erikraft-file-qr-size, 320px), calc(100vw - 24px)) !important;
+        height: min(var(--erikraft-file-qr-size, 320px), calc(100vw - 24px)) !important;
+        max-width: calc(100vw - 24px) !important;
+        max-height: calc(100vw - 24px) !important;
+    }
+}
+@media (max-width: 360px) {
+    #animated-qr-send-dialog #qr-send-canvas-container:has(+ *) {
+        width: min(var(--erikraft-file-qr-size, 320px), calc(100vw - 20px)) !important;
+        height: min(var(--erikraft-file-qr-size, 320px), calc(100vw - 20px)) !important;
+        max-width: calc(100vw - 20px) !important;
+        max-height: calc(100vw - 20px) !important;
+    }
+}
+`;
+        document.head.appendChild(style);
+    }
+
+    function init() {
+        injectResponsiveSizing();
+        bindSizeControl();
+        resetWhenFileClears();
+        applyFileDefault();
+
+        const dialog = document.getElementById('animated-qr-send-dialog');
+        if (dialog && !dialog.dataset.erikraftFileSizeDialogObserver) {
+            dialog.dataset.erikraftFileSizeDialogObserver = 'true';
+            const observer = new MutationObserver(() => {
+                bindSizeControl();
+                if (isFileTransferActive()) applyFileDefault();
+            });
+            observer.observe(dialog, { childList: true, subtree: true });
+        }
+    }
+
+    if (document.readyState === 'loading') {
+        document.addEventListener('DOMContentLoaded', init, { once: true });
+    } else {
+        init();
+    }
+})();

--- a/public/scripts/main.js
+++ b/public/scripts/main.js
@@ -310,7 +310,7 @@ class ErikrafTdrop {
         }
         else if (urlParams.has('base64text')) {
             const base64Text = urlParams.get('base64text');
-            await this.base64Dialog?.evaluateBase64Text(base64text, hash);
+            await this.base64Dialog?.evaluateBase64Text(base64Text, hash);
         }
         else if (urlParams.has('base64zip')) {
             const base64Zip = urlParams.get('base64zip');

--- a/public/scripts/main.js
+++ b/public/scripts/main.js
@@ -19,6 +19,7 @@ class ErikrafTdrop {
             'scripts/qr-helper.js',
             'scripts/erikraft-qr.js',
             'scripts/animated-qr-controls.js',
+            'scripts/animated-qr-file-size.js',
             'scripts/network.js',
             'scripts/ui.js',
             'scripts/libs/heic2any.min.js',
@@ -309,7 +310,7 @@ class ErikrafTdrop {
         }
         else if (urlParams.has('base64text')) {
             const base64Text = urlParams.get('base64text');
-            await this.base64Dialog?.evaluateBase64Text(base64Text, hash);
+            await this.base64Dialog?.evaluateBase64Text(base64text, hash);
         }
         else if (urlParams.has('base64zip')) {
             const base64Zip = urlParams.get('base64zip');


### PR DESCRIPTION
## Objetivo

Corrigir a apresentação do QR Code Animado no modo **Transferência de Arquivo**. O QR de Texto já está visualmente correto; o problema do Arquivo é a percepção de QR pequeno causada pela combinação entre a área reservada do `#qr-send-canvas-container`, o tamanho efetivo do QR e o excesso de espaço visual ao redor.

## Diagnóstico do master atual

O master atual é o merge commit `74086834025c7f992af968af6b2e3f4f8ed49439` (PR #435). O helper de QR já reaplica `width`/`height` e `margin` nas atualizações de frames, e o modo de arquivo já usa margem reduzida de 4px. O controle de tamanho continua sendo Pequeno/Médio/Grande.

O problema restante é que o tamanho visual do container pode não acompanhar o tamanho solicitado pelo controle, enquanto QR Codes de arquivo são mais densos e aparentam ser menores. Por isso esta PR mantém o renderer/protocolo existente e sincroniza apenas a apresentação do modo Arquivo.

## Alterações

- Adiciona `public/scripts/animated-qr-file-size.js`.
- No modo Transferência de Arquivo, quando o usuário ainda não escolheu explicitamente um tamanho, o padrão passa a ser **Grande (320px)**, alinhado ao tamanho Grande já definido para o QR Animado.
- A escolha explícita de `Pequeno`, `Médio` ou `Grande` continua sendo respeitada e não é sobrescrita.
- O `#qr-send-canvas-container` acompanha o tamanho selecionado: 220px, 280px ou 320px.
- Em telas menores, o tamanho é limitado responsivamente pela largura disponível para evitar overflow/corte.
- Ao limpar o arquivo, o estado temporário da preferência automática é resetado para que um novo arquivo volte a iniciar em Grande por padrão.
- A sincronização usa apenas o modo Arquivo (`#qr-send-file-info` + `#qr-send-canvas-container`), sem alterar o QR de Texto.
- O carregamento do novo script acontece imediatamente depois de `animated-qr-controls.js`, garantindo que os controles existentes e o renderer continuem sendo a fonte da lógica funcional.

## Preservado obrigatoriamente

- Protocolo e geração dos frames do QR Animado.
- Reprodução, pausa, anterior, próximo, seek e entrada numérica de frame.
- ECC/FPS/chunk size.
- Layouts existentes.
- `Tamanho`: Pequeno, Médio e Grande.
- Correções anteriores de scroll/responsividade.
- Correções anteriores de tema Claro/Escuro/Automático.
- A redução de margem do PR #435.
- Diálogos **Emparelhamento** e **Sala Pública Temporária** não são alterados.

## Validação esperada

Verificar no desktop e mobile:

1. Transferência de Texto continua visualmente igual.
2. Transferência de Arquivo inicia em **Grande** quando não houve escolha manual.
3. Selecionar Pequeno/Médio/Grande altera o QR e o container proporcionalmente.
4. Nenhuma opção de tamanho é sobrescrita após uma escolha manual.
5. Em mobile estreito, o QR não sai da tela nem impede a rolagem do diálogo.
6. A área branca desnecessária não volta a crescer apenas por causa do container.
7. A geração e troca contínua dos frames continuam funcionando normalmente.

Esta PR é intencionalmente isolada e não altera a lógica de transferência.
