### PR TITLE
fix: match Animated QR file visuals to text and improve light-theme titles

### DIFF
--- a/public/scripts/animated-qr-file-size.js
+++ b/public/scripts/animated-qr-file-size.js
@@ -5,7 +5,7 @@
     const DISPLAY_SIZE_ID = 'qr-send-display-size';
     const CANVAS_ID = 'qr-send-canvas-container';
     const DEFAULT_FILE_SIZE = 'large';
-    // These are the exact layout-1 sizes used by the Animated QR text transfer.
+    // Exact layout-1 sizes used by the Animated QR text transfer.
     const SIZE_PX = { small: 220, medium: 280, large: 320 };
 
     const getEl = id => document.getElementById(id);
@@ -22,8 +22,8 @@
 
     function getResponsiveSize(size) {
         const viewportWidth = window.innerWidth || document.documentElement.clientWidth || size;
-        const horizontalAllowance = viewportWidth <= 360 ? 12 : 24;
-        return Math.max(1, Math.min(size, viewportWidth - horizontalAllowance));
+        const allowance = viewportWidth <= 360 ? 12 : 24;
+        return Math.max(1, Math.min(size, viewportWidth - allowance));
     }
 
     function syncCanvasSize() {
@@ -40,9 +40,9 @@
         container.style.maxWidth = `${renderedSize}px`;
         container.style.maxHeight = `${renderedSize}px`;
 
-        // Do not leave the SVG at its old intrinsic 280px dimensions. The
-        // text-transfer QR uses the selected layout-1 size as its actual
-        // rendered box, so the file-transfer QR must do the same.
+        // Force the actual SVG/canvas box to the same dimensions as text QR.
+        // This prevents an intrinsic 280px SVG from remaining visually small
+        // after the user selects Grande (320px).
         container.querySelectorAll('svg, canvas').forEach(element => {
             element.style.width = `${renderedSize}px`;
             element.style.height = `${renderedSize}px`;
@@ -60,8 +60,8 @@
         const select = getEl(DISPLAY_SIZE_ID);
         if (!select || !isFileTransferActive()) return;
 
-        // File transfer starts at Large, matching the text-transfer Large size.
-        // Once the user changes Tamanho, never overwrite that explicit choice.
+        // File transfer starts at Large, matching Animated QR text Large.
+        // An explicit user selection always wins.
         if (select.dataset.erikraftUserSizeSelection !== 'true') {
             select.value = DEFAULT_FILE_SIZE;
         }
@@ -138,11 +138,15 @@
     min-width: var(--erikraft-file-qr-rendered-size, 320px) !important;
     min-height: var(--erikraft-file-qr-rendered-size, 320px) !important;
 }
-@media (max-width: 360px) {
-    #animated-qr-send-dialog #qr-send-canvas-container.erikraft-file-qr-transfer {
-        width: var(--erikraft-file-qr-rendered-size, 320px) !important;
-        height: var(--erikraft-file-qr-rendered-size, 320px) !important;
-    }
+
+/* In the light theme, QR dialog headers already use a blue surface like
+   Emparelhamento/Sala Pública Temporária, so their titles must be white. */
+body.light-theme #animated-qr-main-dialog .dialog-title,
+body.light-theme #animated-qr-send-dialog .dialog-title,
+body.light-theme #animated-qr-receive-dialog .dialog-title,
+body.light-theme #qr-scanner-dialog .dialog-title,
+body.light-theme #qr-scanner-confirm-dialog .dialog-title {
+    color: #ffffff !important;
 }
 `;
         document.head.appendChild(style);

--- a/public/scripts/animated-qr-file-size.js
+++ b/public/scripts/animated-qr-file-size.js
@@ -5,7 +5,7 @@
     const DISPLAY_SIZE_ID = 'qr-send-display-size';
     const CANVAS_ID = 'qr-send-canvas-container';
     const DEFAULT_FILE_SIZE = 'large';
-    // Keep the file-transfer QR dimensions identical to the text-transfer QR.
+    // These are the exact layout-1 sizes used by the Animated QR text transfer.
     const SIZE_PX = { small: 220, medium: 280, large: 320 };
 
     const getEl = id => document.getElementById(id);
@@ -20,24 +20,39 @@
         return SIZE_PX[select?.value] || SIZE_PX[DEFAULT_FILE_SIZE];
     }
 
-    function syncContainerSize() {
+    function getResponsiveSize(size) {
+        const viewportWidth = window.innerWidth || document.documentElement.clientWidth || size;
+        const horizontalAllowance = viewportWidth <= 360 ? 12 : 24;
+        return Math.max(1, Math.min(size, viewportWidth - horizontalAllowance));
+    }
+
+    function syncCanvasSize() {
         const container = getEl(CANVAS_ID);
         if (!container || !isFileTransferActive()) return;
 
-        const size = getSelectedSize();
+        const requestedSize = getSelectedSize();
+        const renderedSize = getResponsiveSize(requestedSize);
         container.classList.add('erikraft-file-qr-transfer');
-        container.style.setProperty('--erikraft-file-qr-size', `${size}px`);
-        container.style.width = `min(${size}px, calc(100vw - 24px))`;
-        container.style.height = `min(${size}px, calc(100vw - 24px))`;
-        container.style.maxWidth = 'calc(100vw - 24px)';
-        container.style.maxHeight = 'calc(100vw - 24px)';
+        container.style.setProperty('--erikraft-file-qr-size', `${requestedSize}px`);
+        container.style.setProperty('--erikraft-file-qr-rendered-size', `${renderedSize}px`);
+        container.style.width = `${renderedSize}px`;
+        container.style.height = `${renderedSize}px`;
+        container.style.maxWidth = `${renderedSize}px`;
+        container.style.maxHeight = `${renderedSize}px`;
 
+        // Do not leave the SVG at its old intrinsic 280px dimensions. The
+        // text-transfer QR uses the selected layout-1 size as its actual
+        // rendered box, so the file-transfer QR must do the same.
         container.querySelectorAll('svg, canvas').forEach(element => {
-            element.style.width = '100%';
-            element.style.height = '100%';
-            element.style.maxWidth = '100%';
-            element.style.maxHeight = '100%';
+            element.style.width = `${renderedSize}px`;
+            element.style.height = `${renderedSize}px`;
+            element.style.maxWidth = `${renderedSize}px`;
+            element.style.maxHeight = `${renderedSize}px`;
+            element.style.minWidth = `${renderedSize}px`;
+            element.style.minHeight = `${renderedSize}px`;
             element.style.display = 'block';
+            element.setAttribute('width', String(renderedSize));
+            element.setAttribute('height', String(renderedSize));
         });
     }
 
@@ -45,11 +60,12 @@
         const select = getEl(DISPLAY_SIZE_ID);
         if (!select || !isFileTransferActive()) return;
 
-        // Large is the file-transfer default, but an explicit user choice always wins.
+        // File transfer starts at Large, matching the text-transfer Large size.
+        // Once the user changes Tamanho, never overwrite that explicit choice.
         if (select.dataset.erikraftUserSizeSelection !== 'true') {
             select.value = DEFAULT_FILE_SIZE;
         }
-        syncContainerSize();
+        syncCanvasSize();
     }
 
     function bindSizeControl() {
@@ -59,7 +75,7 @@
         select.dataset.erikraftFileSizeBound = 'true';
         select.addEventListener('change', () => {
             select.dataset.erikraftUserSizeSelection = 'true';
-            syncContainerSize();
+            syncCanvasSize();
         });
     }
 
@@ -77,43 +93,13 @@
                 delete select.dataset.erikraftUserSizeSelection;
                 const container = getEl(CANVAS_ID);
                 container?.classList.remove('erikraft-file-qr-transfer');
-                container?.style.removeProperty('--erikraft-file-qr-size');
                 if (container) {
-                    container.style.removeProperty('width');
-                    container.style.removeProperty('height');
-                    container.style.removeProperty('max-width');
-                    container.style.removeProperty('max-height');
+                    ['--erikraft-file-qr-size', '--erikraft-file-qr-rendered-size'].forEach(property => container.style.removeProperty(property));
+                    ['width', 'height', 'max-width', 'max-height'].forEach(property => container.style.removeProperty(property));
                 }
             }
         });
         observer.observe(fileInfo, { childList: true, characterData: true, subtree: true });
-    }
-
-    function wrapQRRenderer() {
-        if (window.ErikrafTDropQR?.__erikraftFileSizeRendererWrapped) return;
-        const qr = window.ErikrafTDropQR;
-        if (!qr || typeof qr.render !== 'function') return;
-
-        const originalRender = qr.render.bind(qr);
-        qr.render = (container, data, options = {}) => {
-            const fileTransfer = container?.id === CANVAS_ID && isFileTransferActive();
-            if (!fileTransfer) return originalRender(container, data, options);
-
-            const size = getSelectedSize();
-            const fileOptions = {
-                ...options,
-                width: size,
-                height: size,
-                // Remove unnecessary SVG background/padding while retaining the
-                // same outer dimensions as the text-transfer QR.
-                margin: 0,
-                animatedTransfer: true
-            };
-            const result = originalRender(container, data, fileOptions);
-            syncContainerSize();
-            return result;
-        };
-        qr.__erikraftFileSizeRendererWrapped = true;
     }
 
     function observeCanvas() {
@@ -122,10 +108,8 @@
 
         container.dataset.erikraftFileCanvasObserver = 'true';
         const observer = new MutationObserver(() => {
-            if (isFileTransferActive()) syncContainerSize();
+            if (isFileTransferActive()) syncCanvasSize();
         });
-        // Observe only rendered children. Do not observe attributes because
-        // syncContainerSize intentionally updates inline sizing styles.
         observer.observe(container, { childList: true, subtree: true });
     }
 
@@ -135,36 +119,29 @@
         style.id = 'erikraft-animated-qr-file-size-style';
         style.textContent = `
 #animated-qr-send-dialog #qr-send-canvas-container.erikraft-file-qr-transfer {
-    width: min(var(--erikraft-file-qr-size, 320px), calc(100vw - 24px)) !important;
-    height: min(var(--erikraft-file-qr-size, 320px), calc(100vw - 24px)) !important;
-    max-width: calc(100vw - 24px) !important;
-    max-height: calc(100vw - 24px) !important;
+    width: var(--erikraft-file-qr-rendered-size, 320px) !important;
+    height: var(--erikraft-file-qr-rendered-size, 320px) !important;
+    max-width: var(--erikraft-file-qr-rendered-size, 320px) !important;
+    max-height: var(--erikraft-file-qr-rendered-size, 320px) !important;
     min-width: 0 !important;
     min-height: 0 !important;
     margin: 4px auto !important;
+    overflow: hidden !important;
 }
 #animated-qr-send-dialog #qr-send-canvas-container.erikraft-file-qr-transfer > svg,
 #animated-qr-send-dialog #qr-send-canvas-container.erikraft-file-qr-transfer > canvas {
     display: block !important;
-    width: 100% !important;
-    height: 100% !important;
-    max-width: 100% !important;
-    max-height: 100% !important;
-}
-@media (max-width: 600px) {
-    #animated-qr-send-dialog #qr-send-canvas-container.erikraft-file-qr-transfer {
-        width: min(var(--erikraft-file-qr-size, 320px), calc(100vw - 20px)) !important;
-        height: min(var(--erikraft-file-qr-size, 320px), calc(100vw - 20px)) !important;
-        max-width: calc(100vw - 20px) !important;
-        max-height: calc(100vw - 20px) !important;
-    }
+    width: var(--erikraft-file-qr-rendered-size, 320px) !important;
+    height: var(--erikraft-file-qr-rendered-size, 320px) !important;
+    max-width: none !important;
+    max-height: none !important;
+    min-width: var(--erikraft-file-qr-rendered-size, 320px) !important;
+    min-height: var(--erikraft-file-qr-rendered-size, 320px) !important;
 }
 @media (max-width: 360px) {
     #animated-qr-send-dialog #qr-send-canvas-container.erikraft-file-qr-transfer {
-        width: min(var(--erikraft-file-qr-size, 320px), calc(100vw - 12px)) !important;
-        height: min(var(--erikraft-file-qr-size, 320px), calc(100vw - 12px)) !important;
-        max-width: calc(100vw - 12px) !important;
-        max-height: calc(100vw - 12px) !important;
+        width: var(--erikraft-file-qr-rendered-size, 320px) !important;
+        height: var(--erikraft-file-qr-rendered-size, 320px) !important;
     }
 }
 `;
@@ -176,8 +153,10 @@
         bindSizeControl();
         resetWhenFileClears();
         observeCanvas();
-        wrapQRRenderer();
         applyFileDefault();
+        window.addEventListener('resize', () => {
+            if (isFileTransferActive()) syncCanvasSize();
+        }, { passive: true });
     }
 
     if (document.readyState === 'loading') {


### PR DESCRIPTION
## Objetivo

Corrigir definitivamente a apresentação visual do **QR Code Animado de Transferência de Arquivo**, fazendo o QR de arquivo seguir o mesmo tamanho/proporção do QR de texto, especialmente quando **Grande** é selecionado em monitores, mobile e emulação de dispositivos.

## Diagnóstico

O `master` mais recente já contém a correção anterior de tamanho, mas a camada específica de arquivo ainda podia deixar o SVG/canvas com dimensões intrínsecas menores (por exemplo, 280px) enquanto o container aparentava estar em Grande. Isso fazia o QR parecer pequeno e mantinha espaço visual branco desnecessário.

O código do controle de QR Animado define o layout 1 do QR de texto como Pequeno 220px, Médio 280px e Grande 320px. Esta correção faz o modo Arquivo usar exatamente essa mesma escala e força o elemento SVG/canvas renderizado a acompanhar o tamanho efetivo disponível.

## Alterações

- Transferência de Arquivo usa exatamente a escala do QR de Texto no layout 1:
  - Pequeno: 220px
  - Médio: 280px
  - Grande: 320px
- Transferência de Arquivo inicia em **Grande** por padrão.
- Uma escolha explícita em `Tamanho` continua sendo respeitada.
- O SVG/canvas não permanece preso ao tamanho intrínseco anterior de 280px.
- O tamanho é sincronizado novamente após a troca de frames e durante resize/orientação do dispositivo.
- O tamanho é limitado apenas pelo espaço real disponível no viewport, evitando overflow em celulares estreitos sem reduzir artificialmente o QR em telas maiores.
- Mantida a identidade de QR de **Arquivo**; não transforma o conteúdo/protocolo em QR de Texto.
- Mantida a geração, reprodução e atualização dos frames existentes.
- No tema **Claro**, os títulos dos diálogos de QR Animado e do Leitor de QR Code passam a ser **brancos**, pois os cabeçalhos possuem fundo azul, seguindo a referência visual de **Emparelhamento** e **Sala Pública Temporária**.
- Não foram alterados os diálogos Emparelhamento ou Sala Pública Temporária.
- Não foram alterados protocolo, ECC, FPS, chunking, FEC, scanner ou lógica de transferência.
- As correções anteriores de `.row.center`, rolagem, visibilidade do canvas e temas Claro/Escuro/Automático permanecem preservadas.

## Validação

Verificar principalmente:

1. Desktop: Arquivo Grande tem o mesmo tamanho/proporção visual do Texto Grande.
2. Mobile: Arquivo Grande continua grande e não fica preso em 280px/um canvas visualmente pequeno.
3. Pequeno/Médio/Grande continuam alterando o tamanho corretamente.
4. Troca contínua de frames não reduz o QR.
5. Rotação/redimensionamento do dispositivo mantém o QR proporcional.
6. A área branca desnecessária não volta a dominar o espaço visual.
7. Tema Claro deixa os títulos dos diálogos de QR brancos sobre o cabeçalho azul.
8. Tema Escuro e Automático não sofrem alteração indevida.
