### PR TITLE
fix: prevent stale CDN cache from serving broken Drop shell

### DIFF
--- a/server/server.js
+++ b/server/server.js
@@ -79,6 +79,22 @@ export default class ErikrafTdropServer {
             next();
         });
 
+        // The application shell and non-hashed runtime assets must not be kept
+        // indefinitely by an intermediate CDN/browser HTTP cache. The Service
+        // Worker owns the versioned offline cache; HTTP delivery should remain
+        // revalidatable so a new deployment can reach clients reliably.
+        app.use((req, res, next) => {
+            const requestPath = req.path;
+            if (requestPath === '/' || requestPath === '/index.html' || requestPath === '/service-worker.js' || requestPath === '/manifest.json') {
+                res.setHeader('Cache-Control', 'no-store, no-cache, must-revalidate, proxy-revalidate, max-age=0');
+                res.setHeader('Pragma', 'no-cache');
+                res.setHeader('Expires', '0');
+            } else if (/\.(?:js|css|json)$/i.test(requestPath)) {
+                res.setHeader('Cache-Control', 'no-cache, must-revalidate, max-age=0');
+            }
+            next();
+        });
+
         const publicPathAbs = path.join(__dirname, '../public');
         app.use(express.static(publicPathAbs));
 


### PR DESCRIPTION
## Contexto

A tela branca continua sendo observada em alguns clientes móveis/WebView. A investigação confirmou que a entrega HTTP do shell também precisa ser considerada: o Service Worker possui seu próprio versionamento, mas `express.static()` não impedia uma camada HTTP/CDN de manter HTML/JS/CSS sem hashes por tempo excessivo.

## Correção

- `index.html`, `/`, `service-worker.js` e `manifest.json` recebem `Cache-Control: no-store`.
- JavaScript, CSS e JSON não-hashados recebem `Cache-Control: no-cache, must-revalidate, max-age=0`.
- O middleware é executado antes do `express.static()`, portanto os headers chegam à resposta dos arquivos estáticos.
- Nenhum dado de IndexedDB/localStorage é removido.
- Nenhuma alteração em WebRTC/P2P, Animated QR, EKQR ou protocolo de transferência.

## Por que isso importa

Mesmo com a estratégia do Service Worker corrigida, uma versão antiga do HTML ou de um script crítico entregue pelo cache HTTP pode impedir o cliente de sequer executar o código responsável por atualizar o Service Worker. Como o projeto não usa content hashes para esses arquivos, revalidação é a estratégia segura para o shell atual.

## Produção

O domínio público observado atualmente não está entregando o mesmo conteúdo/versionamento esperado do `master`, portanto não considero a correção validada em produção até que este commit seja implantado pelo provedor que realmente atende `drop.erikraft.com`.

Não foi feito merge direto em `master`.