### PR TITLE
fix: stop startup freeze from Animated QR observer and bump to v1.16.6

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug-report.md
+++ b/.github/ISSUE_TEMPLATE/bug-report.md
@@ -36,7 +36,7 @@ If applicable, add screenshots to help explain the problem.
 
 **Bug occurs on official ErikrafT Drop™ instance https://drop.erikraft.com/**
 No | Yes
-Version: v1.16.5
+Version: v1.16.6
 
 **Bug occurs on self-hosted ErikrafT Drop™ instance**
 No | Yes

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "erikraft-drop",
-  "version": "1.16.5",
+  "version": "1.16.6",
   "type": "module",
   "description": "File sharing by ErikrafT",
   "main": "server/index.js",
@@ -10,7 +10,7 @@
     "build": "echo 'Build step complete'",
     "package:linux": "npm run validate:linux-icon && electron-builder --linux deb --x64",
     "package:windows": "npm run validate:linux-icon && electron-builder --win nsis --x64",
-    "package:flatpak": "npm run validate:linux-icon && flatpak-builder --force-clean --repo=dist/flatpak-repo dist/flatpak flatpak/io.github.erikraft.Drop.yml",
+    "package:flatpak": "npm run validate:linux-icon && flatpak-builder --force-clean --repo=dist/flatpak-repo dist/flatpak io.github.erikraft.Drop.yml",
     "validate:linux-icon": "node scripts/validate-linux-icon.js",
     "test": "node test/isearch-cli.test.js && node test/erikraft-qr.test.js && node test/interoperability.test.js && node test/service-worker-cache.test.js"
   },

--- a/package.json
+++ b/package.json
@@ -10,7 +10,7 @@
     "build": "echo 'Build step complete'",
     "package:linux": "npm run validate:linux-icon && electron-builder --linux deb --x64",
     "package:windows": "npm run validate:linux-icon && electron-builder --win nsis --x64",
-    "package:flatpak": "npm run validate:linux-icon && flatpak-builder --force-clean --repo=dist/flatpak-repo dist/flatpak io.github.erikraft.Drop.yml",
+    "package:flatpak": "npm run validate:linux-icon && flatpak-builder --force-clean --repo=dist/flatpak-repo dist/flatpak flatpak/io.github.erikraft.Drop.yml",
     "validate:linux-icon": "node scripts/validate-linux-icon.js",
     "test": "node test/isearch-cli.test.js && node test/erikraft-qr.test.js && node test/interoperability.test.js && node test/service-worker-cache.test.js"
   },

--- a/public/manifest.json
+++ b/public/manifest.json
@@ -1,7 +1,7 @@
 {
     "name": "ErikrafT Drop™",
     "short_name": "ErikrafT Drop™",
-    "version": "1.16.5",
+    "version": "1.16.6",
     "icons": [
         {"src": "images/android-chrome-192x192.png", "sizes": "192x192", "type": "image/png"},
         {"src": "images/android-chrome-512x512.png", "sizes": "512x512", "type": "image/png"},

--- a/public/scripts/animated-qr-screen-awake.js
+++ b/public/scripts/animated-qr-screen-awake.js
@@ -67,9 +67,23 @@
         if (!button && insertionPoint) { button = document.createElement('button'); button.id = BUTTON_ID; button.type = 'button'; button.className = 'btn btn-rounded btn-dark'; button.addEventListener('click', toggle); }
         if (button && insertionPoint) placeButton(button, insertionPoint); updateButton();
     }
+    function mutationAffectsScreenAwake(records) {
+        return records.some(record => {
+            if (record.type === 'attributes') {
+                return DIALOG_IDS.includes(record.target?.id);
+            }
+            const target = record.target;
+            if (target?.nodeType === Node.ELEMENT_NODE && (target.id === BUTTON_ID || target.closest?.(`#${BUTTON_ID}`))) {
+                return false;
+            }
+            return true;
+        });
+    }
     document.addEventListener('visibilitychange', () => { if (!requested || document.visibilityState !== 'visible') return; if (!wakeLock && 'wakeLock' in navigator) acquire().then(updateButton).catch(() => updateButton()); else updateButton(); });
     window.addEventListener('pagehide', () => { if (noSleep && typeof noSleep.disable === 'function') { try { noSleep.disable(); } catch (_) {} } wakeLock = null; requested = false; });
-    const observer = new MutationObserver(() => ensureButton());
+    const observer = new MutationObserver(records => {
+        if (mutationAffectsScreenAwake(records)) ensureButton();
+    });
     const start = () => { if (!document.body) return; observer.observe(document.body, { childList: true, subtree: true, attributes: true, attributeFilter: ['hidden', 'aria-hidden', 'style', 'class'] }); ensureButton(); };
     if (document.readyState === 'loading') document.addEventListener('DOMContentLoaded', start, { once: true }); else start();
 })();


### PR DESCRIPTION
## Resumo

Corrige o travamento de inicialização observado em Chromium/PC, em que a interface permanece com o nome `Carregando...` e os botões ficam sem interação.

### Causa identificada

O `animated-qr-screen-awake.js` instala um `MutationObserver` sobre todo o `document.body` com observação de atributos. O próprio `ensureButton()`/`updateButton()` altera atributos e conteúdo do botão (`hidden`, `aria-pressed`, `class`, `title` e `textContent`). Isso pode gerar novas mutações que chamam novamente `ensureButton()`, criando um feedback contínuo no DOM exatamente no ponto em que o console deixa de registrar o carregamento dos próximos scripts.

A correção mantém o recurso de Screen Wake Lock/NoSleep, mas filtra as mutações para ignorar alterações causadas pelo próprio botão e só reage a alterações de atributos dos diálogos Animated QR ou a mudanças estruturais relevantes.

### Referência original

A arquitetura foi comparada com o PairDrop oficial, especialmente o uso do Service Worker e o fluxo de carregamento do frontend:
- https://github.com/schlagmichdoch/pairdrop
- https://github.com/schlagmichdoch/PairDrop/blob/master/public/service-worker.js

### Alterações

- Corrigido o feedback loop potencial do `MutationObserver` em `animated-qr-screen-awake.js`.
- Preservado o funcionamento de Wake Lock/NoSleep e do botão de manter a tela ligada.
- `package.json` atualizado para `1.16.6`.
- `public/manifest.json` atualizado para `1.16.6`.
- `.github/ISSUE_TEMPLATE/bug-report.md` atualizado para `v1.16.6`.

### Segurança da alteração

- Não altera protocolo EKQR.
- Não altera WebRTC/P2P.
- Não altera transferência de arquivos.
- Não altera WebChat.
- Não remove funcionalidades.
- Não faz refatoração ampla.
- PR aberta para revisão; não fazer merge automaticamente.

> Observação: a atualização do `public/index.html` e do cacheVersion do `public/service-worker.js` requer uma substituição integral desses arquivos pela API de conteúdo do GitHub nesta sessão; não foi feita uma substituição parcial arriscada para evitar sobrescrever conteúdo existente. Portanto, esta PR deliberadamente não finge que essas duas alterações foram aplicadas.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved screen-awake button behavior by ensuring it updates only when relevant page changes occur.
  * Prevented unrelated changes within the button from triggering unnecessary updates.

* **Chores**
  * Updated the application, web manifest, and bug-report template version to 1.16.6.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->