### PR TITLE
feat: release IDE extensions 10.1.3

### DIFF
--- a/.github/workflows/package-ide-extensions.yml
+++ b/.github/workflows/package-ide-extensions.yml
@@ -1,0 +1,67 @@
+name: Package IDE Extensions
+
+on:
+  push:
+    branches:
+      - fix/ide-extension-10.1.3
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+concurrency:
+  group: package-ide-extensions-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  package:
+    name: Package ${{ matrix.name }}
+    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: true
+      matrix:
+        include:
+          - name: VS Code
+            directory: Extensions/IDE Extension/VS Code Extension/erikraft-drop
+            artifact: erikraft-drop-vscode
+          - name: Open VSX Registry
+            directory: Extensions/IDE Extension/Open VSX Registry Extension/erikraft-drop
+            artifact: erikraft-drop-open-vsx
+
+    defaults:
+      run:
+        working-directory: ${{ matrix.directory }}
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4.4.0
+
+      - name: Setup Node.js
+        uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4.4.0
+        with:
+          node-version: 22.23.2
+          cache: npm
+          cache-dependency-path: ${{ matrix.directory }}/package.json
+
+      - name: Install extension tooling
+        run: npm install --ignore-scripts --no-audit --no-fund
+
+      - name: Verify extension version
+        run: node -e "const p=require('./package.json'); if(p.version !== '10.1.3') throw new Error(`Expected 10.1.3, got ${p.version}`)"
+
+      - name: Package VSIX
+        run: npm run package
+
+      - name: Verify VSIX manifest
+        run: |
+          vsix=$(find . -maxdepth 1 -type f -name '*.vsix' -print -quit)
+          test -n "$vsix"
+          unzip -p "$vsix" extension/package.json > /tmp/extension-package.json
+          node -e "const p=require('/tmp/extension-package.json'); if(p.version !== '10.1.3') throw new Error(`VSIX manifest is ${p.version}`)"
+
+      - name: Upload VSIX artifact
+        uses: actions/upload-artifact@v4
+        with:
+          name: ${{ matrix.artifact }}-10.1.3
+          path: ${{ matrix.directory }}/*.vsix
+          if-no-files-found: error

--- a/.github/workflows/package-ide-extensions.yml
+++ b/.github/workflows/package-ide-extensions.yml
@@ -40,8 +40,6 @@ jobs:
         uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4.4.0
         with:
           node-version: 22.23.2
-          cache: npm
-          cache-dependency-path: ${{ matrix.directory }}/package.json
 
       - name: Install extension tooling
         run: npm install --ignore-scripts --no-audit --no-fund

--- a/Extensions/IDE Extension/Open VSX Registry Extension/erikraft-drop/package.json
+++ b/Extensions/IDE Extension/Open VSX Registry Extension/erikraft-drop/package.json
@@ -2,7 +2,7 @@
   "name": "erikraft-drop",
   "displayName": "ErikrafT Drop™",
   "description": "The easiest way to transfer files across devices.",
-  "version": "9.0.7",
+  "version": "10.1.3",
   "engines": {
     "vscode": "^1.75.0"
   },

--- a/Extensions/IDE Extension/VS Code Extension/erikraft-drop/package.json
+++ b/Extensions/IDE Extension/VS Code Extension/erikraft-drop/package.json
@@ -2,7 +2,7 @@
   "name": "erikraft-drop",
   "displayName": "ErikrafT Drop™",
   "description": "The easiest way to transfer files across devices.",
-  "version": "9.0.7",
+  "version": "10.1.3",
   "engines": {
     "vscode": "^1.75.0"
   },


### PR DESCRIPTION
## Summary
- updates the VS Code extension package to `10.1.3`;
- updates the Open VSX Registry extension package to `10.1.3`;
- adds `.github/workflows/package-ide-extensions.yml`;
- packages both extension variants as `.vsix` artifacts when the workflow is run;
- verifies the package manifest and generated VSIX manifest are both `10.1.3` before upload;
- does not commit generated VSIX binaries to the repository.

## Actions validation
- VS Code packaging completed successfully on GitHub Actions;
- the generated `erikraft-drop-vscode-10.1.3` artifact was uploaded and is available from the workflow run;
- the Open VSX packaging job was initially cancelled while the workflow run was being rerun and is being kept as a separate validation target rather than claiming it passed without a completed job.

The PR remains Draft. No merge is being performed automatically.