### PR TITLE
fix: validate embedded WebTorrent integration correctly

### DIFF
--- a/.github/workflows/packaging-pr-check.yml
+++ b/.github/workflows/packaging-pr-check.yml
@@ -68,9 +68,5 @@ jobs:
           set -euo pipefail
           ! git ls-tree -r --name-only HEAD | grep -Fxq 'public/torrent.html'
           ! git ls-tree -r --name-only HEAD | grep -Fxq 'public/torrent.js'
-          test -s public/scripts/webtorrent-transfer.js
-          grep -Fq "webtorrent@3.0.21" public/scripts/webtorrent-transfer.js
-          grep -Fq "client.seed" public/scripts/webtorrent-transfer.js
-          grep -Fq "client.add" public/scripts/webtorrent-transfer.js
-          grep -Fq "webtorrent-transfer.js" public/scripts/main.js
-          grep -Fq "manifest fallback" public/service-worker.js
+          node test/webtorrent-transfer.test.js
+          node test/service-worker-cache.test.js

--- a/package.json
+++ b/package.json
@@ -12,7 +12,7 @@
     "package:windows": "npm run validate:linux-icon && electron-builder --win nsis --x64 --publish never",
     "package:flatpak": "npm run validate:linux-icon && flatpak-builder --force-clean --repo=dist/flatpak-repo dist/flatpak flatpak/io.github.erikraft.Drop.yml",
     "validate:linux-icon": "node scripts/validate-linux-icon.js",
-    "test": "node test/isearch-cli.test.js && node test/erikraft-qr.test.js && node test/interoperability.test.js && node test/service-worker-cache.test.js"
+    "test": "node test/isearch-cli.test.js && node test/erikraft-qr.test.js && node test/interoperability.test.js && node test/service-worker-cache.test.js && node test/webtorrent-transfer.test.js"
   },
   "author": {
     "name": "ErikrafT",

--- a/test/service-worker-cache.test.js
+++ b/test/service-worker-cache.test.js
@@ -6,6 +6,7 @@ import {fileURLToPath} from 'node:url';
 const root = path.resolve(path.dirname(fileURLToPath(import.meta.url)), '..');
 const publicDir = path.join(root, 'public');
 const serviceWorker = fs.readFileSync(path.join(publicDir, 'service-worker.js'), 'utf8');
+const main = fs.readFileSync(path.join(publicDir, 'scripts', 'main.js'), 'utf8');
 
 const match = serviceWorker.match(/const relativePathsToCache = \[([\s\S]*?)\n\];/);
 assert.ok(match, 'Service Worker cache manifest must be present.');
@@ -31,6 +32,12 @@ for (const required of [
 
 assert.match(serviceWorker, /const cacheVersion = 'v10\.1\.3';/);
 assert.match(serviceWorker, /Promise\.allSettled\(/, 'Service Worker installation must tolerate individual cache failures.');
-assert.match(serviceWorker, /updateViaCache: 'none'/, 'Client registration should bypass the HTTP cache for SW updates.');
+assert.match(main, /updateViaCache: 'none'/, 'Client registration should bypass the HTTP cache for SW updates.');
+assert.match(serviceWorker, /const createManifestFallback = \(\) => new Response\(/,
+    'Service Worker must provide a valid local manifest when a same-origin manifest cannot be fetched.');
+assert.match(serviceWorker, /'Content-Type': 'application\/manifest\+json'/,
+    'Manifest fallback must retain the manifest MIME type.');
+assert.match(serviceWorker, /requestUrl\.pathname\.endsWith\('\/manifest\.json'\)/,
+    'Manifest fallback must apply only to manifest requests.');
 
 console.log(`Service Worker cache manifest OK: ${paths.length} resources verified.`);

--- a/test/webtorrent-transfer.test.js
+++ b/test/webtorrent-transfer.test.js
@@ -1,0 +1,31 @@
+import assert from 'node:assert/strict';
+import fs from 'node:fs';
+import path from 'node:path';
+import {fileURLToPath} from 'node:url';
+
+const root = path.resolve(path.dirname(fileURLToPath(import.meta.url)), '..');
+const read = relativePath => fs.readFileSync(path.join(root, relativePath), 'utf8');
+const transfer = read('public/scripts/webtorrent-transfer.js');
+const main = read('public/scripts/main.js');
+
+assert.ok(transfer.length > 0, 'Embedded WebTorrent transfer module must not be empty.');
+assert.match(transfer, /const WEBTORRENT_VERSION = '3\.0\.21';/,
+    'The embedded transfer must pin the tested WebTorrent version.');
+assert.match(transfer, /import\(`https:\/\/esm\.sh\/webtorrent@\$\{WEBTORRENT_VERSION\}`\)/,
+    'The WebTorrent constructor must be loaded from the pinned version.');
+assert.match(transfer, /const TRACKERS = \[[\s\S]*wss:\/\/tracker\./,
+    'WebTorrent must use WebSocket trackers for browser peer discovery.');
+assert.match(transfer, /torrentClient\.seed\(Array\.from\(input\.files\), \{ announce: TRACKERS \}/,
+    'Sender flow must seed the selected files with the configured trackers.');
+assert.match(transfer, /torrentClient\.add\(magnet, \{ announce: TRACKERS \}\)/,
+    'Receiver flow must add the shared magnet or torrent metadata with the configured trackers.');
+assert.match(transfer, /torrent\.on\('done', async \(\) => \{[\s\S]*file\.blob\(\)/,
+    'Completed downloads must be materialized as downloadable file blobs.');
+assert.match(transfer, /objectUrls\.forEach\(url => URL\.revokeObjectURL\(url\)\)/,
+    'Download object URLs must be released when the page unloads.');
+assert.match(transfer, /if \(client\) client\.destroy\(\);/,
+    'The WebTorrent client must be destroyed when the page unloads.');
+assert.match(main, /'scripts\/webtorrent-transfer\.js'/,
+    'The main application must load the embedded WebTorrent module.');
+
+console.log('Embedded WebTorrent transfer contract OK.');


### PR DESCRIPTION
### Motivation
- The CI job `Validate embedded Torrent surface` used fragile `grep` assertions that failed against the current, correct implementation which loads WebTorrent dynamically and uses a local `torrentClient` variable instead of literal `client.*` calls.
- Replace brittle string checks with executable contract tests that validate the actual integration points (dynamic import, trackers, seed/add flows, blobs, cleanup, and SW manifest behavior).

### Description
- Replace the literal `grep` checks in `.github/workflows/packaging-pr-check.yml` with executable tests that run `node test/webtorrent-transfer.test.js` and `node test/service-worker-cache.test.js` to validate the embedded WebTorrent contract and SW manifest fallback.
- Add `test/webtorrent-transfer.test.js` which asserts the pinned WebTorrent version, dynamic import usage, tracker list, `seed`/`add` callsites, download blob materialization, object URL cleanup, client destruction, and that `main.js` loads the module.
- Update `test/service-worker-cache.test.js` to read `public/scripts/main.js` for the `updateViaCache` assertion and to validate the scoped manifest-fallback `Response` and its `Content-Type` handling.
- Add the new WebTorrent contract test to `npm test` so the check runs locally as well as in the workflow (`package.json` update).

### Testing
- Ran `node test/webtorrent-transfer.test.js` and `node test/service-worker-cache.test.js`, both assertions passed (contract checks OK).
- Ran the full test suite via `npm test` (with `npm_config_engine_strict=false` in this environment to work around a local Node version mismatch) and all repository tests passed including interoperability and QR tests.
- Built artifacts with `npm run build`, validated linux icon (`npm run validate:linux-icon`), produced a Linux `.deb` via `npm run package:linux`, inspected `app.asar` to confirm `public/scripts/webtorrent-transfer.js` is present and `public/torrent.html` / `public/torrent.js` are not (DEB validation passed).
- Noted environment limitation: local runtime had Node `v20.20.2` while the project requires `>=22.12.0`, causing `npm ci` to fail under strict engine checks; CI uses Node `22.23.2` and is expected to run normally there.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6aa2cfafae9c832a9c31771b6c56a757)